### PR TITLE
Create a Fluent Builder for RowObject

### DIFF
--- a/docs/docs/dotnet/data-model/fieldobject.mdx
+++ b/docs/docs/dotnet/data-model/fieldobject.mdx
@@ -20,10 +20,12 @@ class FieldObject {
     +string FieldValue
     +string Lock
     +string Required
+    +Builder() FieldObjectBuilder
     +Clone() FieldObject
     +Equals(FieldObjectBase) bool
     +Equals(object) bool
     +GetHashCode() int
+    +Initialize() FieldObject
     +IsEnabled() bool
     +IsLocked() bool
     +IsModified() bool
@@ -47,18 +49,20 @@ class FieldObject {
 
 | Property        | Description |
 |:----------------|:------------|
-| Enabled         | Gets or sets the Enabled value. The supported case-sensitive values are `N` and `Y`. |
+| Enabled         | Gets or sets the Enabled value. The supported values are `0` (False) and `1` (True). |
 | FieldNumber     | Gets or Sets the FieldNumber value. |
 | FieldValue      | Gets or sets the FieldValue value. |
-| Lock            | Gets or sets the Lock value. The supported case-sensitive values are `N` and `Y`. |
-| Required        | Gets or sets the Required value. The supported case-sensitive values are `N` and `Y`. |
+| Lock            | Gets or sets the Lock value. The supported values are `0` (False) and `1` (True). |
+| Required        | Gets or sets the Required value. The supported values are `0` (False) and `1` (True). |
 
 ## Methods
 
 | Method        | Description |
 |:----------------|:------------|
+| Builder() | Initializes a builder for constructing a FieldObject. |
 | Clone() | Creates a copy of the FieldObject. |
 | GetFieldValue() | Returns the FieldValue of a FieldObject. |
+| Initialize() | Initializes an empty FieldObject. This FieldObject will be disabled, unlocked, and not required upon initialization. |
 | IsEnabled() | Returns whether the FieldObject is enabled. |
 | IsLocked() | Returns whether the FieldObject is locked. |
 | IsModified() | Returns whether the FieldObject has been modified. |
@@ -89,6 +93,7 @@ public void TestMethod1WithFluentBuilder()
     var expected = "value";
     FieldObject fieldObject = FieldObject.Builder()
         .FieldNumber("123.45").FieldValue(expected)
+        .Enabled()
         .Build();
     Assert.AreEqual(expected, fieldObject.FieldValue);
 }
@@ -100,7 +105,8 @@ public void TestMethod1WithSimplifiedConstructor()
     FieldObject fieldObject = new FieldObject
     {
         FieldNumber = "123.45",
-        FieldValue = expected
+        FieldValue = expected,
+        Enabled = "1"
     };
     Assert.AreEqual(expected, fieldObject.FieldValue);
 }
@@ -115,6 +121,7 @@ public void TestMethod1WithSimplifiedConstructor()
     Dim expected As String = "value"
     Dim fieldObject As FieldObject.Builder()
         .FieldNumber("123.45").FieldValue(expected)
+        .Enabled()
         .Build()
     Assert.AreEqual(expected, fieldObject.FieldValue)
 End Sub
@@ -123,7 +130,8 @@ End Sub
     Dim expected As String = "value"
     Dim fieldObject As New FieldObject With {
         .FieldNumber = "123.45",
-        .FieldValue = expected
+        .FieldValue = expected,
+        .Enabled = "1"
     }
     Assert.AreEqual(expected, fieldObject.FieldValue)
 End Sub
@@ -137,7 +145,9 @@ End Sub
 ```mermaid
 classDiagram
 class FieldObject {
+    +Builder() FieldObjectBuilder
     +Clone() FieldObject
+    +Initialize() FieldObject
     +ToXml() string
 }
 

--- a/docs/docs/dotnet/data-model/rowobject.mdx
+++ b/docs/docs/dotnet/data-model/rowobject.mdx
@@ -24,11 +24,13 @@ class RowObject {
     +AddFieldObject(string, string)
     +AddFieldObject(string, string, string, string, string)
     +AddFieldObject(string, string, bool, bool, bool)
+    +Builder() RowObjectBuilder
     +Clone() RowObject
     +Equals(RowObjectBase)
     +Equals(object)
     +GetFieldValue(string) string
     +GetHashCode()
+    +Initialize() RowObject
     +IsFieldEnabled(string) bool
     +IsFieldLocked(string) bool
     +IsFieldModified(string) bool
@@ -86,8 +88,10 @@ click FieldObject href "./fieldobject" "Learn more about the FieldObject"
 | AddFieldObject(string, string) | Adds a [FieldObject](../fieldobject) to a RowObject using supplied FieldNumber and FieldValue. |
 | AddFieldObject(string, string, string, string, string) | Adds a [FieldObject](../fieldobject) to a RowObject using supplied FieldNumber and FieldValue and setting the Enabled, Locked, and Required values (e.g., `Y` or `N`). |
 | AddFieldObject(string, string, bool, bool, bool) | Adds a [FieldObject](../fieldobject) to a RowObject using supplied FieldNumber and FieldValue and setting the Enabled, Locked, and Required values. |
+| Builder() | Initializes a builder for constructing a RowObject. |
 | Clone() | Creates a copy of the RowObject. |
 | GetFieldValue(string) | Returns the FieldValue of a [FieldObject](../fieldobject) in a RowObject by FieldNumber. |
+| Initialize() | Initializes an empty RowObject. This RowAction will be set to None upon initialization. |
 | IsFieldEnabled(string) | Returns whether a [FieldObject](../fieldobject) in a RowObject is enabled by FieldNumber. |
 | IsFieldLocked(string) | Returns whether a [FieldObject](../fieldobject) in a RowObject is locked by FieldNumber. |
 | IsFieldPresent(string) | Returns whether a [FieldObject](../fieldobject) in a RowObject is present by FieldNumber. |
@@ -118,14 +122,35 @@ Most implementations would not require working with the RowObject directly, howe
 <TabItem value="cs" label="C#">
 
 ```cs
+// Available in v1.2 or later
 [TestMethod]
-public void TestMethod1()
+public void TestMethod1WithFluentBuilder()
 {
     var expected = "value";
+    RowObject rowObject = RowObject.Builder()
+        .RowId("123||45")
+        .Field().FieldNumber("246.80").FieldValue("Sample").Enabled().Add()
+        .Edit()
+        .Build();
+    Assert.AreEqual(expected, rowObject.RowId);
+}
+
+[TestMethod]
+public void TestMethod1WithSimplifiedConstructor()
+{
+    var expected = "value";
+    FieldObject fieldObject = new FieldObject
+    {
+        FieldNumber = "246.80",
+        FieldValue = "Sample",
+        Enabled = "1"
+    };
     RowObject rowObject = new RowObject
     {
-        RowId = "123||45"
+        RowId = "123||45",
+        RowAction = "EDIT"
     };
+    rowObject.AddFieldObject(fieldObject);
     Assert.AreEqual(expected, rowObject.RowId);
 }
 ```
@@ -134,10 +159,27 @@ public void TestMethod1()
 <TabItem value="vb" label="Visual Basic">
 
 ```vb
-<TestMethod()> Public Sub TestMethod1()
+// Available in v1.2 or later
+<TestMethod()> Public Sub TestMethod1WithFluentBuilder()
     Dim expected As String = "value"
+    Dim rowObject As RowObject.Builder()
+        .RowId("123||45")
+        .Field().FieldNumber("246.80").FieldValue("Sample").Enabled().Add()
+        .Edit()
+        .Build();
+    Assert.AreEqual(expected, rowObject.RowId)
+End Sub
+
+<TestMethod()> Public Sub TestMethod1WithSimplifiedConstructor()
+    Dim expected As String = "value"
+    Dim fieldObject As New FieldObject With {
+        .FieldNumber = "246.80",
+        .FieldValue = "Sample",
+        .Enabled = "1"
+    }
     Dim rowObject As New RowObject With {
-        .RowId = "123||45"
+        .RowId = "123||45",
+        .RowAction = "EDIT"
     }
     Assert.AreEqual(expected, rowObject.RowId)
 End Sub
@@ -152,7 +194,9 @@ End Sub
 classDiagram
 direction LR
 class RowObject {
+    +Builder() RowObjectBuilder
     +Clone() RowObject
+    +Initialize() RowObject
     +ToXml() string
 }
 

--- a/docs/docs/dotnet/intro.md
+++ b/docs/docs/dotnet/intro.md
@@ -10,7 +10,7 @@ AvatarScriptLink.NET is a framework for managing and manipulating [Netsmart myAv
 
 Most ScriptLink-compatible APIs are built with a local version of the NTST.ScriptLinkService.Objects library. Here's what a "Hello, World!" response might look like in this scenario.
 
-```cs
+```cs title="Without AvatarScriptLink.NET"
 [WebMethod]
 public OptionObject RunScript(OptionObject optionObject, string parameter)
 {
@@ -33,7 +33,7 @@ public OptionObject RunScript(OptionObject optionObject, string parameter)
 
 With AvatarScriptLink.NET, this same code can be simplified to:
 
-```cs
+```cs title="With AvatarScriptLink.NET"
 [WebMethod]
 public OptionObject RunScript(OptionObject optionObject, string parameter)
 {
@@ -43,7 +43,7 @@ public OptionObject RunScript(OptionObject optionObject, string parameter)
 
 Likewise, to bring this same API up to the latest OptionObject version doesn't require accounting for the new properties. Just update the OptionObject version and import the new/updated WSDL into myAvatar.
 
-```cs
+```cs title="Upgrading from OptionObject to OptionObject2015"
 [WebMethod]
 public OptionObject2015 RunScript(OptionObject2015 optionObject, string parameter)
 {

--- a/docs/src/components/HomepageHelloWorld/index.js
+++ b/docs/src/components/HomepageHelloWorld/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import clsx from 'clsx';
 import styles from './styles.module.css';
 import CodeBlock from '@theme/CodeBlock';
 
@@ -16,7 +15,7 @@ export default function HomepageHelloWorld() {
                 <div className='row'>
                     <div className='col col--3'>
                         <h3>Before</h3>
-                        <p>Before AvatarScriptLink.NET you would have to construct your return OptionObject manually.</p>
+                        <p>Before AvatarScriptLink.NET you would have to construct your return OptionObject manually and often make changes directly to the incoming OptionObject.</p>
                     </div>
                     <div className='col col--9'>
                         <CodeBlock
@@ -26,16 +25,23 @@ public OptionObject2015 RunScript(OptionObject2015 optionObject, string paramete
 {
     OptionObject returnOptionObject = new OptionObject();
 
-    returnOptionObject.ErrorCode = 3;
-    returnOptionObject.ErrorMesg = "Hello, World!";
-
     returnOptionObject.EntityID = optionObject.EntityID;
     returnOptionObject.EpisodeNumber = optionObject.EpisodeNumber;
     returnOptionObject.Facility = optionObject.Facility;
+    returnOptionObject.Forms = optionObject.Forms;
+    returnOptionObject.NamespaceName = optionObject.NamespaceName;
     returnOptionObject.OptionId = optionObject.OptionId;
     returnOptionObject.OptionStaffId = optionObject.OptionStaffId;
     returnOptionObject.OptionUserId = optionObject.OptionUserId;
+    returnOptionObject.ParentNamespace = optionObject.ParentNamespace;
+    returnOptionObject.ServerName = optionObject.ServerName;
     returnOptionObject.SystemCode = optionObject.SystemCode;
+    returnOptionObject.SessionToken = optionObject.SessionToken;
+
+    // Do work here on returnOptionObject and prepare for return
+
+    returnOptionObject.ErrorCode = 3;
+    returnOptionObject.ErrorMesg = "Informational message...";
 
     return returnOptionObject;
 }`}
@@ -45,15 +51,18 @@ public OptionObject2015 RunScript(OptionObject2015 optionObject, string paramete
                 <div className='row'>
                     <div className='col col--3'>
                         <h3>After</h3>
-                        <p>Afterwards, you can construct your return OptionObject directly from the object received.</p>
+                        <p>Afterwards, you can construct your working copy of the OptionObject directly from the object received.</p>
+                        <p>You can also prepare the OptionObject for return as well as set the ErrorCode and ErrorMesg in a single command.</p>
                     </div>
                     <div className='col col--9'>
                         <CodeBlock
                             language='csharp'>
                             {`[WebMethod]
-public OptionObject2015 RunScript(OptionObject2015 optionObject, string parameters)
+public OptionObject2015 RunScript(OptionObject2015 incomingOptionObject, string parameters)
 {
-    return optionObject.ToReturnOptionObject(ErrorCode.Alert, "Hello, World!");
+    OptionObject2015 optionObject = incomingOptionObject.Clone();
+    // Do work here on the clone of incoming OptionObject to retain original request for later comparison or restore
+    return optionObject.ToReturnOptionObject(ErrorCode.Informational, "Informational message...");
 }`}
                         </CodeBlock>
                     </div>

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/RowObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/RowObjectTests.cs
@@ -17,9 +17,9 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
 
         [TestMethod]
         [TestCategory("RowObject")]
-        public void RowObject_FieldsObjectIsNotEmpty()
+        public void RowObject_FieldsObjectIsEmpty()
         {
-            RowObject rowObject = new RowObject();
+            RowObject rowObject = RowObject.Initialize();
             List<FieldObject> expected = new List<FieldObject>();
             var actual = rowObject.Fields;
             Assert.AreNotEqual(expected, actual);
@@ -29,12 +29,10 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("RowObject")]
         public void RowObjects_AreEqual()
         {
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Build();
             RowObject rowObject2 = new RowObject
             {
                 ParentRowId = "1",
@@ -50,12 +48,10 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("RowObject")]
         public void RowObjects_AreNotEqual()
         {
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Build();
             RowObject rowObject2 = new RowObject
             {
                 ParentRowId = "1",
@@ -72,18 +68,11 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         public void RowObjects_GetFieldValue_AreEqual()
         {
             string expected = "TEST";
-            FieldObject fieldObject = new FieldObject
-            {
-                FieldNumber = "123",
-                FieldValue = ""
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber("123").Add()
+                .Build();
 
             rowObject1.SetFieldValue("123", expected);
             string actual = rowObject1.GetFieldValue("123");
@@ -95,21 +84,19 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("RowObject")]
         public void RowObjects_GetFieldValue_AreNotEqual()
         {
+            string fieldNumber = "123";
             string expected = "TEST";
-            FieldObject fieldObject = new FieldObject
-            {
-                FieldNumber = "123",
-                FieldValue = ""
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber(fieldNumber)
+                .FieldValue("")
+                .Build();
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field(fieldObject)
+                .Build();
 
-            string actual = rowObject1.GetFieldValue("123");
+            string actual = rowObject1.GetFieldValue(fieldNumber);
 
             Assert.AreNotEqual(expected, actual);
         }
@@ -120,21 +107,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         {
             string fieldNumber = "123";
             string expected = "TEST";
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = fieldNumber,
-                FieldValue = expected,
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject
-            {
-                ParentRowId = "",
-                RowAction = "",
-                RowId = "1||1"
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber(fieldNumber)
+                .FieldValue(expected)
+                .Enabled()
+                .Build();
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Field(fieldObject)
+                .Build();
+
             rowObject.AddFieldObject(fieldObject);
+
             Assert.AreEqual(expected, rowObject.GetFieldValue(fieldNumber));
         }
 
@@ -144,12 +128,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         {
             string fieldNumber = "123";
             string expected = "TEST";
-            RowObject rowObject = new RowObject
-            {
-                ParentRowId = "",
-                RowAction = "",
-                RowId = "1||1"
-            };
+            RowObject rowObject = RowObject.Builder().RowId("1||1").Build();
             rowObject.AddFieldObject(fieldNumber, expected, "1", "0", "0");
             Assert.AreEqual(expected, rowObject.GetFieldValue(fieldNumber));
         }
@@ -160,12 +139,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         {
             string fieldNumber = "123";
             string expected = "TEST";
-            RowObject rowObject = new RowObject
-            {
-                ParentRowId = "",
-                RowAction = "",
-                RowId = "1||1"
-            };
+            RowObject rowObject = RowObject.Builder().RowId("1||1").Build();
             rowObject.AddFieldObject(fieldNumber, expected, true, false, false);
             Assert.AreEqual(expected, rowObject.GetFieldValue(fieldNumber));
         }
@@ -177,12 +151,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         {
             string fieldNumber = "123";
             int expected = 1;
-            RowObject rowObject = new RowObject
-            {
-                ParentRowId = "",
-                RowAction = "",
-                RowId = "1||1"
-            };
+            RowObject rowObject = RowObject.Builder().RowId("1||1").Build();
             rowObject.AddFieldObject(fieldNumber, "TEST", "1", "0", "0");
             Assert.AreEqual("TEST", rowObject.GetFieldValue(fieldNumber));
 
@@ -195,113 +164,68 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("RowObject")]
         public void RowObject_IsFieldEnabled_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Build();
 
-            Assert.IsFalse(rowObject1.IsFieldEnabled("123"));
+            Assert.IsFalse(rowObject1.IsFieldEnabled(fieldNumber));
         }
 
         [TestMethod]
         [TestCategory("RowObject")]
         public void RowObject_IsFieldEnabled_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Enabled().Add()
+                .Build();
 
-            Assert.IsTrue(rowObject1.IsFieldEnabled("123"));
+            Assert.IsTrue(rowObject1.IsFieldEnabled(fieldNumber));
         }
 
         [TestMethod]
         [TestCategory("RowObject")]
         public void RowObject_IsFieldLocked_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Build();
 
-            Assert.IsFalse(rowObject1.IsFieldLocked("123"));
+            Assert.IsFalse(rowObject1.IsFieldLocked(fieldNumber));
         }
 
         [TestMethod]
         [TestCategory("RowObject")]
         public void RowObject_IsFieldLocked_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "1",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Locked().Add()
+                .Build();
 
-            Assert.IsTrue(rowObject1.IsFieldLocked("123"));
+            Assert.IsTrue(rowObject1.IsFieldLocked(fieldNumber));
         }
 
         [TestMethod]
         [TestCategory("RowObject")]
         public void RowObject_IsFieldPresent_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Build();
 
             Assert.IsFalse(rowObject1.IsFieldPresent("234"));
         }
@@ -310,108 +234,59 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("RowObject")]
         public void RowObject_IsFieldPresent_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Build();
 
-            Assert.IsTrue(rowObject1.IsFieldPresent("123"));
+            Assert.IsTrue(rowObject1.IsFieldPresent(fieldNumber));
         }
 
         [TestMethod]
         [TestCategory("RowObject")]
         public void RowObject_IsFieldRequired_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Build();
 
-            Assert.IsFalse(rowObject1.IsFieldRequired("123"));
+            Assert.IsFalse(rowObject1.IsFieldRequired(fieldNumber));
         }
 
         [TestMethod]
         [TestCategory("RowObject")]
         public void RowObject_IsFieldRequired_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject);
+            string fieldNumber = "123";
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Required().Add()
+                .Build();
 
-            Assert.IsTrue(rowObject1.IsFieldRequired("123"));
+            Assert.IsTrue(rowObject1.IsFieldRequired(fieldNumber));
         }
 
         [TestMethod]
         [TestCategory("RowObject")]
         public void RowObject_RemoveFieldObject_ByObject()
         {
-            FieldObject fieldObject1 = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            FieldObject fieldObject2 = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "124",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            FieldObject fieldObject3 = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "125",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject1);
-            rowObject1.Fields.Add(fieldObject2);
-            rowObject1.Fields.Add(fieldObject3);
+            FieldObject fieldObject2 = FieldObject.Builder()
+                .FieldNumber("124").FieldValue("TEST")
+                .Enabled().Required()
+                .Build();
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber("123").FieldValue("TEST").Enabled().Required().Add()
+                .Field(fieldObject2)
+                .Field().FieldNumber("125").FieldValue("TEST").Enabled().Required().Add()
+                .Build();
             
             rowObject1.RemoveFieldObject(fieldObject2);
 
@@ -423,39 +298,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("RowObject")]
         public void RowObject_RemoveFieldObject_ByFieldNumber()
         {
-            FieldObject fieldObject1 = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            FieldObject fieldObject2 = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "124",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            FieldObject fieldObject3 = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "125",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                ParentRowId = "1",
-                RowAction = "",
-                RowId = "1"
-            };
-            rowObject1.Fields.Add(fieldObject1);
-            rowObject1.Fields.Add(fieldObject2);
-            rowObject1.Fields.Add(fieldObject3);
+            FieldObject fieldObject2 = FieldObject.Builder()
+                .FieldNumber("124").FieldValue("TEST")
+                .Enabled().Required()
+                .Build();
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1")
+                .ParentRowId("1")
+                .Field().FieldNumber("123").FieldValue("TEST").Enabled().Required().Add()
+                .Field(fieldObject2)
+                .Field().FieldNumber("125").FieldValue("TEST").Enabled().Required().Add()
+                .Build();
 
             rowObject1.RemoveFieldObject(fieldObject2.FieldNumber);
 
@@ -688,12 +541,11 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestMethod]
         public void RowObject_Clone_AreEqual()
         {
-            List<FieldObject> fieldObjects = new List<FieldObject>
-            {
-                new FieldObject("123", "Test"),
-                new FieldObject("124", "Test 2")
-            };
-            RowObject rowObject = new RowObject("1||1", fieldObjects);
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Field().FieldNumber("123").FieldValue("Test").Add()
+                .Field().FieldNumber("124").FieldValue("Test 2").Add()
+                .Build();
 
             RowObject cloneObject = rowObject.Clone();
 
@@ -706,12 +558,11 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestMethod]
         public void RowObject_Clone_AreNotEqual()
         {
-            List<FieldObject> fieldObjects = new List<FieldObject>
-            {
-                new FieldObject("123", "Test"),
-                new FieldObject("124", "Test 2")
-            };
-            RowObject rowObject = new RowObject("1||1", fieldObjects);
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Field().FieldNumber("123").FieldValue("Test").Add()
+                .Field().FieldNumber("124").FieldValue("Test 2").Add()
+                .Build();
 
             RowObject cloneObject = rowObject.Clone();
             rowObject.RemoveFieldObject("123");
@@ -720,6 +571,45 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             Assert.AreNotEqual(rowObject, cloneObject);
             Assert.IsFalse(rowObject.IsFieldPresent("123"));
             Assert.IsTrue(cloneObject.IsFieldPresent("123"));
+        }
+
+        [TestMethod]
+        public void RowObject_Builder_ActionIsAdd()
+        {
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Add()
+                .Build();
+            Assert.AreEqual(RowAction.Add, rowObject.RowAction);
+        }
+
+        [TestMethod]
+        public void RowObject_Builder_ActionIsDelete()
+        {
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Delete()
+                .Build();
+            Assert.AreEqual(RowAction.Delete, rowObject.RowAction);
+        }
+
+        [TestMethod]
+        public void RowObject_Builder_ActionIsEdit()
+        {
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Edit()
+                .Build();
+            Assert.AreEqual(RowAction.Edit, rowObject.RowAction);
+        }
+
+        [TestMethod]
+        public void RowObject_Builder_ActionIsNone()
+        {
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Build();
+            Assert.AreEqual(RowAction.None, rowObject.RowAction);
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/RowObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/RowObjectTests.cs
@@ -114,7 +114,6 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
                 .Build();
             RowObject rowObject = RowObject.Builder()
                 .RowId("1||1")
-                .Field(fieldObject)
                 .Build();
 
             rowObject.AddFieldObject(fieldObject);

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/FieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/FieldObject.cs
@@ -1,7 +1,7 @@
-﻿using RarelySimple.AvatarScriptLink.Objects.Advanced;
-using RarelySimple.AvatarScriptLink.Helpers;
-using System.Globalization;
+﻿using RarelySimple.AvatarScriptLink.Helpers;
+using RarelySimple.AvatarScriptLink.Objects.Advanced;
 using System;
+using System.Globalization;
 
 namespace RarelySimple.AvatarScriptLink.Objects
 {
@@ -44,10 +44,24 @@ namespace RarelySimple.AvatarScriptLink.Objects
         { }
 
         /// <summary>
+        /// Initializes a FieldObject.
+        /// </summary>
+        /// <returns>A <see cref="FieldObject"/></returns>
+        public static FieldObject Initialize() {
+            return new FieldObject();
+        }
+
+        /// <summary>
         /// Initializes a <see cref="FieldObjectBuilder"/> to help construct a <see cref="FieldObject"/>.
         /// The implementation must set the FieldNumber before build may be completed.
         /// <code>
-        /// FieldObject fieldObject = FieldObject.Builder().FieldNumber("123").Build();
+        /// // Sample usage
+        /// FieldObject fieldObject = FieldObject.Builder()
+        ///                                      .FieldNumber("123")
+        ///                                      .FieldValue("Sample")
+        ///                                      .Enabled()
+        ///                                      .Required()
+        ///                                      .Build();
         /// </code>
         /// </summary>
         /// <returns>A <see cref="FieldObjectBuilder"/>.</returns>
@@ -88,13 +102,8 @@ namespace RarelySimple.AvatarScriptLink.Objects
                 };
             }
             /// <summary>
-            /// Constructs a FieldObjectBuilder to resume work on an existing <see cref="FieldObject"/>.
-            /// </summary>
-            /// <param name="fieldObject"></param>
-            protected FieldObjectBuilder(FieldObject fieldObject) => _fieldObject = fieldObject;
-            /// <summary>
             /// Sets the FieldNumber for the FieldObject to build.
-            /// This is required before any other attributes may be set or the <see cref="FieldObject"/> built.
+            /// This is required before any other attributes may be set on the <see cref="FieldObject"/> built.
             /// </summary>
             /// <param name="fieldNumber">Required. The FieldNumber assigned to the <see cref="FieldObject"/></param>
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> allowing for the setting of other attributes and building of the <see cref="FieldObject"/></returns>
@@ -109,12 +118,18 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// <summary>
         /// Fluent Builder class for the completion of a <see cref="FieldObject"/> build.
         /// </summary>
-        public class FieldObjectBuilderFinal : FieldObjectBuilder {
+        public class FieldObjectBuilderFinal
+        {
+            protected readonly FieldObject _fieldObject;
+
             /// <summary>
             /// Constructs a <see cref="FieldObjectBuilderFinal"/> to resume building of a <see cref="FieldObject"/>.
             /// </summary>
             /// <param name="fieldObject"></param>
-            public FieldObjectBuilderFinal(FieldObject fieldObject) : base(fieldObject) { }
+            public FieldObjectBuilderFinal(FieldObject fieldObject)
+            {
+                _fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture)); ;
+            }
             /// <summary>
             /// Sets the <see cref="FieldObject"/> to build as enabled.
             /// </summary>
@@ -167,6 +182,120 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// </summary>
             /// <returns>A <see cref="FieldObject"/>.</returns>
             public FieldObject Build() => _fieldObject;
+        }
+
+        /// <summary>
+        /// Fluent Builder class for constructing FieldObjects.
+        /// </summary>
+        public class RowObjectFieldObjectBuilder
+        {
+            protected readonly FieldObject _fieldObject;
+            protected readonly RowObject _rowObject;
+
+            /// <summary>
+            /// Constructs a FieldObjectBuilder with Enabled, Locked, and Required set to false by default.
+            /// </summary>
+            public RowObjectFieldObjectBuilder(RowObject rowObject)
+            {
+                _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                _fieldObject = new FieldObject();
+            }
+            /// <summary>
+            /// Constructs a FieldObjectBuilder to resume work on an existing <see cref="FieldObject"/>.
+            /// </summary>
+            /// <param name="fieldObject"></param>
+            protected RowObjectFieldObjectBuilder(FieldObject fieldObject, RowObject rowObject)
+            {
+                _fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Sets the FieldNumber for the FieldObject to build.
+            /// This is required before any other attributes may be set or the <see cref="FieldObject"/> built.
+            /// </summary>
+            /// <param name="fieldNumber">Required. The FieldNumber assigned to the <see cref="FieldObject"/></param>
+            /// <returns>A <see cref="FieldObjectBuilderFinal"/> allowing for the setting of other attributes and building of the <see cref="FieldObject"/></returns>
+            public RowObjectFieldObjectBuilderFinal FieldNumber(string fieldNumber)
+            {
+                if (string.IsNullOrEmpty(fieldNumber))
+                    throw new ArgumentNullException(nameof(fieldNumber), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                _fieldObject.FieldNumber = fieldNumber;
+                return new RowObjectFieldObjectBuilderFinal(_fieldObject, _rowObject);
+            }
+        }
+        /// <summary>
+        /// Fluent Builder class for the completion of a <see cref="FieldObject"/> build.
+        /// </summary>
+        public class RowObjectFieldObjectBuilderFinal
+        {
+            protected readonly FieldObject _fieldObject;
+            protected readonly RowObject _rowObject;
+
+            /// <summary>
+            /// Constructs a <see cref="FieldObjectBuilderFinal"/> to resume building of a <see cref="FieldObject"/>.
+            /// </summary>
+            /// <param name="fieldObject"></param>
+            public RowObjectFieldObjectBuilderFinal(FieldObject fieldObject, RowObject rowObject) {
+                _fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+
+            /// <summary>
+            /// Sets the <see cref="FieldObject"/> to build as enabled.
+            /// </summary>
+            /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectFieldObjectBuilderFinal Enabled()
+            {
+                _fieldObject._enabled = "1";
+                return this;
+            }
+            /// <summary>
+            /// Sets the FieldValue of the <see cref="FieldObject"/> to build.
+            /// </summary>
+            /// <param name="fieldValue">The value this <see cref="FieldObject"/> is to be set to.</param>
+            /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectFieldObjectBuilderFinal FieldValue(string fieldValue)
+            {
+                _fieldObject.FieldValue = fieldValue;
+                return this;
+            }
+            /// <summary>
+            /// Sets the <see cref="FieldObject"/> to build as locked.
+            /// </summary>
+            /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectFieldObjectBuilderFinal Locked()
+            {
+                _fieldObject._locked = "1";
+                return this;
+            }
+            /// <summary>
+            /// Sets the <see cref="FieldObject"/> to build as modified.
+            /// <para>Allow the FieldObject to be returned in a return OptionObject.</para>
+            /// </summary>
+            /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectFieldObjectBuilderFinal Modified()
+            {
+                _fieldObject._modified = true;
+                return this;
+            }
+            /// <summary>
+            /// Sets the <see cref="FieldObject"/> to build as required.
+            /// </summary>
+            /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectFieldObjectBuilderFinal Required()
+            {
+                _fieldObject._required = "1";
+                return this;
+            }
+            /// <summary>
+            /// Builds the <see cref="FieldObject"/> based on the supplied build parameters.
+            /// </summary>
+            /// <returns>A <see cref="FieldObject"/>.</returns>
+            public RowObject.RowObjectBuilderFinal Add()
+            {
+                _rowObject.Fields.Add(_fieldObject);
+                return new RowObject.RowObjectBuilderFinal(_rowObject);
+            }
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/RowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/RowObject.cs
@@ -1,6 +1,8 @@
-﻿using RarelySimple.AvatarScriptLink.Objects.Advanced;
-using RarelySimple.AvatarScriptLink.Helpers;
+﻿using RarelySimple.AvatarScriptLink.Helpers;
+using RarelySimple.AvatarScriptLink.Objects.Advanced;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace RarelySimple.AvatarScriptLink.Objects
 {
@@ -67,6 +69,34 @@ namespace RarelySimple.AvatarScriptLink.Objects
             : base(rowId, fieldObjects, parentRowId, rowAction)
         { }
 
+        /// <summary>
+        /// Initializes a <see cref="RowObject"/>
+        /// </summary>
+        /// <returns>A <see cref="FieldObject"/></returns>
+        public static RowObject Initialize()
+        {
+            return new RowObject();
+        }
+
+        /// <summary>
+        /// Initializes a <see cref="RowObjectBuilder"/> to help construct a <see cref="RowObject"/>.
+        /// The implementation must set the RowId before build may be completed.
+        /// <code>
+        /// // Sample usage
+        /// RowObject rowObject = RowObject.Builder()
+        ///                                .RowId("1||2")
+        ///                                .ParentRowId("1||1")
+        ///                                .Field(fieldObject)
+        ///                                .Field().FieldNumber("123.45").FieldValue("Sample").Enabled().Add()
+        ///                                .Add()  // Sets RowAction to "ADD"
+        ///                                .Build();
+        /// </code>
+        /// </summary>
+        /// <returns></returns>
+        public static RowObjectBuilder Builder()
+        {
+            return new RowObjectBuilder();
+        }
 
         /// <summary>
         /// Returns a deep copy of the <see cref="RowObject"/>.
@@ -88,5 +118,122 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         /// <returns><see cref="string"/> of all of the contents of the <see cref="RowObject"/> formatted as XML.</returns>
         public override string ToXml() => OptionObjectHelpers.TransformToXml(this);
+
+        /// <summary>
+        /// Fluent Builder for contructing RowObjects
+        /// </summary>
+        public class RowObjectBuilder
+        {
+            protected readonly RowObject _rowObject;
+
+            /// <summary>
+            /// Constructs a RowObjectBuilder with the RowAction set to None by default.
+            /// </summary>
+            public RowObjectBuilder()
+            {
+                _rowObject = new RowObject()
+                {
+                    RowAction = ""
+                };
+            }
+            /// <summary>
+            /// Sets the RowId of the <see cref="RowObject"/> to build.
+            /// This is required before any other attributes may be set on the <see cref="RowObject"/> built.
+            /// </summary>
+            /// <param name="rowId">Required. The RowId assigned to the <see cref="RowObject"/></param>
+            /// <returns>A <see cref="RowObjectBuilderFinal"/> allowing for the setting of other attributes and building of the <see cref="RowObject"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public RowObjectBuilderFinal RowId(string rowId)
+            {
+                if(string.IsNullOrEmpty(rowId))
+                    throw new ArgumentNullException(nameof(rowId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                _rowObject.RowId = rowId;
+                return new RowObjectBuilderFinal(_rowObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a <see cref="RowObject"/> build.
+        /// </summary>
+        public class RowObjectBuilderFinal
+        {
+            protected readonly RowObject _rowObject;
+
+            /// <summary>
+            /// Constructs a RowObjectBuilderFinal used to complete build of a <see cref="RowObject"/>.
+            /// </summary>
+            /// <param name="rowObject"></param>
+            /// <exception cref="ArgumentNullException"></exception>
+            public RowObjectBuilderFinal(RowObject rowObject)
+            {
+                _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Sets the RowAction to Add for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="RowObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectBuilderFinal Add()
+            {
+                _rowObject.RowAction = Objects.RowAction.Add;
+                return this;
+            }
+            /// <summary>
+            /// Sets the RowAction to Delete for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="RowObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectBuilderFinal Delete()
+            {
+                _rowObject.RowAction = Objects.RowAction.Delete;
+                return this;
+            }
+            /// <summary>
+            /// Sets the RowAction to Edit for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="RowObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectBuilderFinal Edit()
+            {
+                _rowObject.RowAction = Objects.RowAction.Edit;
+                return this;
+            }
+            /// <summary>
+            /// Sets the ParentRowId for this <see cref="RowObject"/>
+            /// </summary>
+            /// <param name="parentRowId">The RowId of the parent RowObject</param>
+            /// <returns>A <see cref="RowObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectBuilderFinal ParentRowId(string parentRowId)
+            {
+                _rowObject.ParentRowId = parentRowId;
+                return this;
+            }
+            /// <summary>
+            /// Initializes a builder to construct a FieldObject within the RowObject builder.
+            /// </summary>
+            /// <returns>A <see cref="RowObjectFieldObjectBuilder"/> to start <see cref="FieldObject"/> build</returns>
+            public FieldObject.RowObjectFieldObjectBuilder Field()
+            {
+                return new FieldObject.RowObjectFieldObjectBuilder(_rowObject);
+            }
+            /// <summary>
+            /// Adds a <see cref="FieldObject"/> to the <see cref="RowObject"/>
+            /// </summary>
+            /// <param name="fieldObject">The <see cref="FieldObject"/> to add</param>
+            /// <returns>A <see cref="RowObjectBuilderFinal"/> to resume build.</returns>
+            public RowObjectBuilderFinal Field(FieldObject fieldObject)
+            {
+                if (_rowObject.Fields == null)
+                {
+                    _rowObject.Fields = new List<FieldObject>();
+                }
+                _rowObject.Fields.Add(fieldObject);
+                return this;
+            }
+            /// <summary>
+            /// Builds the <see cref="RowObject"/> based on the supplied build parameters.
+            /// </summary>
+            /// <returns>A <see cref="RowObject"/></returns>
+            public RowObject Build()
+            {
+                return _rowObject;
+            }
+        }
     }
 }


### PR DESCRIPTION
This update introduces a Fluent Builder for the RowObject that includes a nested FieldObjectBuilder.
```cs
FieldObject fieldObject = FieldObject.Builder()
    .FieldNumber("123.46")
    .FieldValue("Test")
    .Enabled()
    .Build();
RowObject rowObject = RowObject.Builder()
    .RowId("1||5")
    .ParentRowId("1||1")
    .Field().FieldNumber("123.45").FieldValue("Sample").Enabled().Required().Add() // Adds FieldObject to RowObject
    .Field(fieldObject)    // Adds existing FieldObject to RowObject
    .Add() // Sets the RowAction to Add
    .Build();
```
This update also introduces an optional Initializer method for the RowObject and FieldObject classes.
```cs
RowObject rowObject = RowObject.Initializer();
```
This is functionally identical to `new RowObject()` at this time.

The documentation site has also been updated to reflect these changes.