### PR TITLE
Create FormObject Fluent Builder

### DIFF
--- a/docs/docs/dotnet/data-model/formobject.mdx
+++ b/docs/docs/dotnet/data-model/formobject.mdx
@@ -23,11 +23,13 @@ class FormObject {
     +AddRowObject(RowObject)
     +AddRowObject(string, string)
     +AddRowObject(string, string, string)
+    +Builder() FormObjectBuilder
     +Clone() FormObject
     +DeleteRowObject(RowObject)
     +DeleteRowObject(string)
     +Equals(FormObjectBase) bool
     +Equals(object) bool
+    +Initialize() FormObject
     +GetCurrentRowId() string
     +GetFieldValue(string) string
     +GetFieldValue(string, string) string
@@ -91,6 +93,7 @@ click RowObject href "./rowobject" "Learn more about the RowObject"
 | AddRowObject([RowObject](../rowobject)) | Adds a [RowObject](../rowobject) to a the FormObject. |
 | AddRowObject(string, string) | Adds a [RowObject](../rowobject) to a FormObject using supplied RowId and ParentRowId. |
 | AddRowObject(string, string, string) | Adds a [RowObject](../rowobject) to a FormObject using supplied RowId and ParentRowId and setting the RowAction. |
+| Builder() | Initializes a builder for constructing a FormObject. |
 | Clone() | Creates a copy of the FormObject. |
 | DeleteRowObject([RowObject](../rowobject)) | Removes a [RowObject](../rowobject) from a FormObject. |
 | DeleteRowObject(string) | Removes a [RowObject](../rowobject) from a FormObject by RowId. |
@@ -103,6 +106,7 @@ click RowObject href "./rowobject" "Learn more about the RowObject"
 | GetFieldValues(string) | Returns a List&lt;string&gt; of FieldValues in a FormObject by FieldNumber. |
 | GetNextAvailableRowId() | Returns the next available RowId for the FormObject. |
 | GetParentRowId() | Returns the ParentRowId of the FormObject.CurrentRow. |
+| Initialize() | Initializes an empty FormObject. |
 | IsFieldEnabled(string) | Returns whether a [FieldObject](../fieldobject) in a FormObject is enabled by FieldNumber. |
 | IsFieldLocked(string) | Returns whether a [FieldObject](../fieldobject) in a FormObject is locked by FieldNumber. |
 | IsFieldModified(string) | Returns whether a [FieldObject](../fieldobject) in a FormObject is modified by FieldNumber. |
@@ -143,13 +147,37 @@ Most implementations would not require working with the FormObject directly, how
 <TabItem value="cs" label="C#">
 
 ```cs
+// Available in v1.2 or later
 [TestMethod]
-public void TestMethod1()
+public void TestMethod1WithFluentBuilder()
 {
-    var expected = "value";
-    FormObject formObject = new FormObject
+    var expected = "123";
+    // FieldObject and RowObject definitions here 
+    FormObject formObject = FormObject.Builder()
+        .FormId(expected)
+        .CurrentRow()
+            .RowId("123||1")
+            .Field(fieldObject1)
+            .Field(fieldObject2)
+            .AddRow()
+        .MultipleIteration()
+        .OtherRow()
+            .RowId("123||2")
+            .Field(fieldObject3)
+            .Field(fieldObject4)
+            .AddRow()
+        .OtherRow(rowObject)
+        .Build();
+    Assert.AreEqual(expected, formObject.FormId);
+}
+
+[TestMethod]
+public void TestMethod1WithSimplifiedConstructor()
+{
+    var expected = "123";
+    FormObject formObject = new FormObject()
     {
-        FormId = "123"
+        FormId = expected
     };
     Assert.AreEqual(expected, formObject.FormId);
 }
@@ -159,10 +187,33 @@ public void TestMethod1()
 <TabItem value="vb" label="Visual Basic">
 
 ```vb
-<TestMethod()> Public Sub TestMethod1()
-    Dim expected As String = "value"
+' Available in v1.2 or later
+<TestMethod()> Public Sub TestMethod1WithFluentBuilder()
+    Dim expected As String = "123"
+    ' FieldObject and RowObject definitions here 
+    Dim formObject As FormObject.Builder()
+        .FormId(expected)
+        .CurrentRow()
+            .RowId("123||1")
+            .Field(fieldObject1)
+            .Field(fieldObject2)
+            .AddRow()
+        .MultipleIteration()
+        .OtherRow()
+            .RowId("123||2")
+            .Field(fieldObject3)
+            .Field(fieldObject4)
+            .AddRow()
+        .OtherRow(rowObject)
+        .Build()
+    Assert.AreEqual(expected, formObject.FormId)
+End Sub
+
+
+<TestMethod()> Public Sub TestMethod1WithSimplifiedConstructor()
+    Dim expected As String = "123"
     Dim formObject As New FormObject With {
-        .FormId = "123"
+        .FormId = expected
     }
     Assert.AreEqual(expected, formObject.FormId)
 End Sub
@@ -177,7 +228,9 @@ End Sub
 classDiagram
 direction LR
 class FormObject {
+    +Builder() FormObjectBuilder
     +Clone() FormObject
+    +Initialize() FormObject
     +ToXml() string
 }
 

--- a/docs/docs/dotnet/data-model/rowobject.mdx
+++ b/docs/docs/dotnet/data-model/rowobject.mdx
@@ -126,10 +126,10 @@ Most implementations would not require working with the RowObject directly, howe
 [TestMethod]
 public void TestMethod1WithFluentBuilder()
 {
-    var expected = "value";
+    var expected = "123||1";
     RowObject rowObject = RowObject.Builder()
-        .RowId("123||45")
-        .Field().FieldNumber("246.80").FieldValue("Sample").Enabled().Add()
+        .RowId(expected)
+        .Field().FieldNumber("246.80").FieldValue("Sample").Enabled().AddField()
         .Edit()
         .Build();
     Assert.AreEqual(expected, rowObject.RowId);
@@ -138,7 +138,7 @@ public void TestMethod1WithFluentBuilder()
 [TestMethod]
 public void TestMethod1WithSimplifiedConstructor()
 {
-    var expected = "value";
+    var expected = "123||1";
     FieldObject fieldObject = new FieldObject
     {
         FieldNumber = "246.80",
@@ -147,7 +147,7 @@ public void TestMethod1WithSimplifiedConstructor()
     };
     RowObject rowObject = new RowObject
     {
-        RowId = "123||45",
+        RowId = expected,
         RowAction = "EDIT"
     };
     rowObject.AddFieldObject(fieldObject);
@@ -159,28 +159,29 @@ public void TestMethod1WithSimplifiedConstructor()
 <TabItem value="vb" label="Visual Basic">
 
 ```vb
-// Available in v1.2 or later
+' Available in v1.2 or later
 <TestMethod()> Public Sub TestMethod1WithFluentBuilder()
-    Dim expected As String = "value"
+    Dim expected As String = "123||1"
     Dim rowObject As RowObject.Builder()
-        .RowId("123||45")
-        .Field().FieldNumber("246.80").FieldValue("Sample").Enabled().Add()
+        .RowId(expected)
+        .Field().FieldNumber("246.80").FieldValue("Sample").Enabled().AddField()
         .Edit()
         .Build();
     Assert.AreEqual(expected, rowObject.RowId)
 End Sub
 
 <TestMethod()> Public Sub TestMethod1WithSimplifiedConstructor()
-    Dim expected As String = "value"
+    Dim expected As String = "123||1"
     Dim fieldObject As New FieldObject With {
         .FieldNumber = "246.80",
         .FieldValue = "Sample",
         .Enabled = "1"
     }
     Dim rowObject As New RowObject With {
-        .RowId = "123||45",
+        .RowId = expected,
         .RowAction = "EDIT"
     }
+    rowObject.AddFieldObject(fieldObject)
     Assert.AreEqual(expected, rowObject.RowId)
 End Sub
 ```

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/FormObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/FormObjectTests.cs
@@ -12,7 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_HasOtherRowsObject()
         {
-            FormObject formObject = new FormObject();
+            FormObject formObject = FormObject.Initialize();
             Assert.IsNotNull(formObject.OtherRows);
         }
 
@@ -20,7 +20,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_OtherRowsObject_IsNotEmpty()
         {
-            FormObject formObject = new FormObject();
+            FormObject formObject = FormObject.Initialize();
             List<RowObject> expected = new List<RowObject>();
             var actual = formObject.OtherRows;
             Assert.AreNotEqual(expected, actual);
@@ -30,7 +30,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_Default_MultipleIteration_IsFalse()
         {
-            FormObject formObject = new FormObject();
+            FormObject formObject = FormObject.Initialize();
             Assert.IsFalse(formObject.MultipleIteration);
         }
 
@@ -38,10 +38,10 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_CanSetMultipleIteration()
         {
-            var formObject = new FormObject
-            {
-                MultipleIteration = true
-            };
+            var formObject = FormObject.Builder()
+                .FormId("1")
+                .MultipleIteration()
+                .Build();
             Assert.IsTrue(formObject.MultipleIteration);
             formObject.MultipleIteration = false;
             Assert.IsFalse(formObject.MultipleIteration);
@@ -51,18 +51,10 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_AddRowObject_NoMI_RowObject()
         {
-            RowObject rowObject1 = new RowObject
-            {
-                RowId = "1||1"
-            };
-            RowObject rowObject2 = new RowObject
-            {
-                RowId = "1||2"
-            };
-            FormObject formObject = new FormObject
-            {
-                MultipleIteration = false
-            };
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1||1")
+                .Build();
+            FormObject formObject = FormObject.Initialize();
 
             formObject.AddRowObject(rowObject1);
             Assert.AreEqual(rowObject1, formObject.CurrentRow);
@@ -74,18 +66,13 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(ArgumentException))]
         public void FormObject_AddRowObject_NoMI_RowObject_Exception()
         {
-            RowObject rowObject1 = new RowObject
-            {
-                RowId = "1||1"
-            };
-            RowObject rowObject2 = new RowObject
-            {
-                RowId = "1||2"
-            };
-            FormObject formObject = new FormObject
-            {
-                MultipleIteration = false
-            };
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1||1")
+                .Build();
+            RowObject rowObject2 = RowObject.Builder()
+                .RowId("1||2")
+                .Build();
+            FormObject formObject = FormObject.Initialize();
 
             formObject.AddRowObject(rowObject1);
             formObject.AddRowObject(rowObject2);
@@ -97,18 +84,16 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_AddRowObject_MI_RowObject()
         {
-            RowObject rowObject1 = new RowObject
-            {
-                RowId = "1||1"
-            };
-            RowObject rowObject2 = new RowObject
-            {
-                RowId = "1||2"
-            };
-            FormObject formObject = new FormObject
-            {
-                MultipleIteration = true
-            };
+            RowObject rowObject1 = RowObject.Builder()
+                .RowId("1||1")
+                .Build();
+            RowObject rowObject2 = RowObject.Builder()
+                .RowId("1||2")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .MultipleIteration()
+                .Build();
 
             formObject.AddRowObject(rowObject1);
             Assert.AreEqual(rowObject1, formObject.CurrentRow);
@@ -123,11 +108,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_AddRowObject_Properties_NoRowAction()
         {
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
+            FormObject formObject = FormObject.Builder().FormId("1").Build();
 
             formObject.AddRowObject("1||1", "");
             Assert.AreEqual("1||1", formObject.CurrentRow.RowId);
@@ -139,11 +120,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_AddRowObject_Properties_with_RowAction()
         {
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
+            FormObject formObject = FormObject.Builder().FormId("1").Build();
 
             formObject.AddRowObject("1||1", "", "");
             Assert.AreEqual("1||1", formObject.CurrentRow.RowId);
@@ -155,7 +132,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_CanGetHtmlString_WithoutHtmlHeaders()
         {
-            FormObject formObject = new FormObject();
+            FormObject formObject = FormObject.Initialize();
             var actual = formObject.ToHtmlString(false);
             Assert.IsNotNull(actual);
         }
@@ -164,7 +141,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_CanGetHtmlString_WithHtmlHeaders()
         {
-            FormObject formObject = new FormObject();
+            FormObject formObject = FormObject.Initialize();
             var actual = formObject.ToHtmlString(false);
             Assert.IsNotNull(actual);
         }
@@ -174,7 +151,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(NullReferenceException))]
         public void FormObject_GetCurrentRowId_IsError()
         {
-            FormObject formObject = new FormObject();
+            FormObject formObject = FormObject.Initialize();
             var actual = formObject.GetCurrentRowId();
             Assert.AreEqual(null, actual);
         }
@@ -184,11 +161,12 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         public void FormObject_GetCurrentRowId_AreEqual()
         {
             string expected = "1||1";
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = new RowObject()
-            };
-            formObject.CurrentRow.RowId = expected;
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId(expected)
+                    .AddRow()
+                .Build();
             var actual = formObject.GetCurrentRowId();
             Assert.AreEqual(expected, actual);
         }
@@ -198,7 +176,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(NullReferenceException))]
         public void FormObject_GetParentRowId_IsError()
         {
-            FormObject formObject = new FormObject();
+            FormObject formObject = FormObject.Initialize();
             var actual = formObject.GetParentRowId();
             Assert.AreEqual(null, actual);
         }
@@ -208,11 +186,13 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         public void FormObject_GetParentRowId_AreEqual()
         {
             string expected = "1||1";
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = new RowObject()
-            };
-            formObject.CurrentRow.ParentRowId = expected;
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||2")
+                    .ParentRowId(expected)
+                    .AddRow()
+                .Build();
             var actual = formObject.GetParentRowId();
             Assert.AreEqual(expected, actual);
         }
@@ -221,20 +201,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldEnabled_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Enabled()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsTrue(formObject.IsFieldEnabled("123"));
         }
@@ -243,20 +221,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldEnabled_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsFalse(formObject.IsFieldEnabled("123"));
         }
@@ -266,20 +241,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void FormObject_IsFieldEnabled_NotPresent_Error()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Enabled()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsFalse(formObject.IsFieldEnabled("124"));
         }
@@ -288,20 +261,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldLocked_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "1",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Locked()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsTrue(formObject.IsFieldLocked("123"));
         }
@@ -310,20 +281,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldLocked_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsFalse(formObject.IsFieldLocked("123"));
         }
@@ -333,20 +301,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void FormObject_IsFieldLocked_NotPresent_Error()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "1",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Locked()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsFalse(formObject.IsFieldLocked("124"));
         }
@@ -355,20 +321,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldPresent_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsTrue(formObject.IsFieldPresent("123"));
         }
@@ -377,20 +340,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldPresent_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsFalse(formObject.IsFieldPresent("124"));
         }
@@ -399,20 +359,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldRequired_IsTrue()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Required()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsTrue(formObject.IsFieldRequired("123"));
         }
@@ -421,20 +379,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_IsFieldRequired_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsFalse(formObject.IsFieldRequired("123"));
         }
@@ -444,20 +399,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(ArgumentException))]
         public void FormObject_IsFieldRequired_NotPresent_IsFalse()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "1"
-            };
-            RowObject rowObject = new RowObject();
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Required()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             Assert.IsFalse(formObject.IsFieldRequired("124"));
         }
@@ -466,24 +419,18 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_SetFieldValue_NoMI_AreEqual()
         {
-            FieldObject fieldObject = new FieldObject
-            {
-                Enabled = "1",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject = new RowObject
-            {
-                RowId = "1||1"
-            };
-            rowObject.Fields.Add(fieldObject);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject,
-                MultipleIteration = false
-            };
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Enabled()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow()
+                    .RowId("1||1")
+                    .Field(fieldObject)
+                    .AddRow()
+                .Build();
 
             formObject.SetFieldValue("123", "MODIFIED");
             Assert.AreEqual("MODIFIED", formObject.GetFieldValue("123"));
@@ -495,38 +442,20 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("FormObject")]
         public void FormObject_SetFieldValue_MI_AreEqual()
         {
-            FieldObject fieldObject1 = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                RowId = "1||1"
-            };
-            rowObject1.Fields.Add(fieldObject1);
-            FieldObject fieldObject2 = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST2",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject2 = new RowObject
-            {
-                RowId = "1||2"
-            };
-            rowObject2.Fields.Add(fieldObject2);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject1,
-                MultipleIteration = true
-            };
-            formObject.OtherRows.Add(rowObject2);
+            FieldObject fieldObject1 = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Build();
+            FieldObject fieldObject2 = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST2")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow().RowId("1||1").Field(fieldObject1).AddRow()
+                .MultipleIteration()
+                .OtherRow().RowId("1||2").Field(fieldObject2).AddRow()
+                .Build();
 
             formObject.SetFieldValue("1||2", "123", "MODIFIED");
             Assert.AreNotEqual("MODIFIED", formObject.GetFieldValue("123"));
@@ -539,38 +468,20 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(ArgumentException))]
         public void FormObject_SetFieldValue_MI_Error()
         {
-            FieldObject fieldObject1 = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject1 = new RowObject
-            {
-                RowId = "1||1"
-            };
-            rowObject1.Fields.Add(fieldObject1);
-            FieldObject fieldObject2 = new FieldObject
-            {
-                Enabled = "0",
-                FieldNumber = "123",
-                FieldValue = "TEST2",
-                Lock = "0",
-                Required = "0"
-            };
-            RowObject rowObject2 = new RowObject
-            {
-                RowId = "1||2"
-            };
-            rowObject2.Fields.Add(fieldObject2);
-            FormObject formObject = new FormObject
-            {
-                CurrentRow = rowObject1,
-                MultipleIteration = true
-            };
-            formObject.OtherRows.Add(rowObject2);
+            FieldObject fieldObject1 = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST")
+                .Build();
+            FieldObject fieldObject2 = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("TEST2")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow().RowId("1||1").Field(fieldObject1).AddRow()
+                .MultipleIteration()
+                .OtherRow().RowId("1||2").Field(fieldObject2).AddRow()
+                .Build();
 
             formObject.SetFieldValue("123", "MODIFIED");
             Assert.AreNotEqual("MODIFIED", formObject.GetFieldValue("123"));
@@ -699,12 +610,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestMethod]
         public void FormObject_Clone_AreEqual()
         {
-            List<FieldObject> fieldObjects = new List<FieldObject>
-            {
-                new FieldObject("123", "Test")
-            };
-            RowObject rowObject = new RowObject("1||1", fieldObjects);
-            FormObject formObject = new FormObject("1", rowObject);
+            FieldObject fieldObject = FieldObject.Builder()
+                .FieldNumber("123")
+                .FieldValue("Test")
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow().RowId("1||1").Field(fieldObject).AddRow()
+                .Build();
 
             FormObject cloneObject = formObject.Clone();
 
@@ -716,12 +629,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestMethod]
         public void FormObject_Clone_AreNotEqual()
         {
-            List<FieldObject> fieldObjects = new List<FieldObject>
-            {
-                new FieldObject("123", "Test")
-            };
-            RowObject rowObject = new RowObject("1||1", fieldObjects);
-            FormObject formObject = new FormObject("1", rowObject);
+            RowObject rowObject = RowObject.Builder()
+                .RowId("1||1")
+                .Field().FieldNumber("123").FieldValue("Test").AddField()
+                .Build();
+            FormObject formObject = FormObject.Builder()
+                .FormId("1")
+                .CurrentRow(rowObject)
+                .Build();
 
             FormObject cloneObject = formObject.Clone();
             formObject.DeleteRowObject(rowObject);

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/RowObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/RowObjectTests.cs
@@ -71,7 +71,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber("123").Add()
+                .Field().FieldNumber("123").AddField()
                 .Build();
 
             rowObject1.SetFieldValue("123", expected);
@@ -167,7 +167,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").AddField()
                 .Build();
 
             Assert.IsFalse(rowObject1.IsFieldEnabled(fieldNumber));
@@ -181,7 +181,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Enabled().Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Enabled().AddField()
                 .Build();
 
             Assert.IsTrue(rowObject1.IsFieldEnabled(fieldNumber));
@@ -195,7 +195,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").AddField()
                 .Build();
 
             Assert.IsFalse(rowObject1.IsFieldLocked(fieldNumber));
@@ -209,7 +209,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Locked().Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Locked().AddField()
                 .Build();
 
             Assert.IsTrue(rowObject1.IsFieldLocked(fieldNumber));
@@ -223,7 +223,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").AddField()
                 .Build();
 
             Assert.IsFalse(rowObject1.IsFieldPresent("234"));
@@ -237,7 +237,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").AddField()
                 .Build();
 
             Assert.IsTrue(rowObject1.IsFieldPresent(fieldNumber));
@@ -251,7 +251,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").AddField()
                 .Build();
 
             Assert.IsFalse(rowObject1.IsFieldRequired(fieldNumber));
@@ -265,7 +265,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Required().Add()
+                .Field().FieldNumber(fieldNumber).FieldValue("TEST").Required().AddField()
                 .Build();
 
             Assert.IsTrue(rowObject1.IsFieldRequired(fieldNumber));
@@ -282,9 +282,9 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber("123").FieldValue("TEST").Enabled().Required().Add()
+                .Field().FieldNumber("123").FieldValue("TEST").Enabled().Required().AddField()
                 .Field(fieldObject2)
-                .Field().FieldNumber("125").FieldValue("TEST").Enabled().Required().Add()
+                .Field().FieldNumber("125").FieldValue("TEST").Enabled().Required().AddField()
                 .Build();
             
             rowObject1.RemoveFieldObject(fieldObject2);
@@ -304,9 +304,9 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             RowObject rowObject1 = RowObject.Builder()
                 .RowId("1")
                 .ParentRowId("1")
-                .Field().FieldNumber("123").FieldValue("TEST").Enabled().Required().Add()
+                .Field().FieldNumber("123").FieldValue("TEST").Enabled().Required().AddField()
                 .Field(fieldObject2)
-                .Field().FieldNumber("125").FieldValue("TEST").Enabled().Required().Add()
+                .Field().FieldNumber("125").FieldValue("TEST").Enabled().Required().AddField()
                 .Build();
 
             rowObject1.RemoveFieldObject(fieldObject2.FieldNumber);
@@ -542,8 +542,8 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         {
             RowObject rowObject = RowObject.Builder()
                 .RowId("1||1")
-                .Field().FieldNumber("123").FieldValue("Test").Add()
-                .Field().FieldNumber("124").FieldValue("Test 2").Add()
+                .Field().FieldNumber("123").FieldValue("Test").AddField()
+                .Field().FieldNumber("124").FieldValue("Test 2").AddField()
                 .Build();
 
             RowObject cloneObject = rowObject.Clone();
@@ -559,8 +559,8 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         {
             RowObject rowObject = RowObject.Builder()
                 .RowId("1||1")
-                .Field().FieldNumber("123").FieldValue("Test").Add()
-                .Field().FieldNumber("124").FieldValue("Test 2").Add()
+                .Field().FieldNumber("123").FieldValue("Test").AddField()
+                .Field().FieldNumber("124").FieldValue("Test 2").AddField()
                 .Build();
 
             RowObject cloneObject = rowObject.Clone();

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/FieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/FieldObject.cs
@@ -87,14 +87,14 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         public class FieldObjectBuilder
         {
-            protected readonly FieldObject _fieldObject;
+            protected readonly FieldObject fieldObject;
 
             /// <summary>
             /// Constructs a FieldObjectBuilder with Enabled, Locked, and Required set to false by default.
             /// </summary>
             public FieldObjectBuilder()
             {
-                _fieldObject = new FieldObject
+                fieldObject = new FieldObject
                 {
                     _enabled = "0",
                     _locked = "0",
@@ -111,8 +111,8 @@ namespace RarelySimple.AvatarScriptLink.Objects
             {
                 if (string.IsNullOrEmpty(fieldNumber))
                     throw new ArgumentNullException(nameof(fieldNumber), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-                _fieldObject.FieldNumber = fieldNumber;
-                return new FieldObjectBuilderFinal(_fieldObject);
+                fieldObject.FieldNumber = fieldNumber;
+                return new FieldObjectBuilderFinal(fieldObject);
             }
         }
         /// <summary>
@@ -120,7 +120,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         public class FieldObjectBuilderFinal
         {
-            protected readonly FieldObject _fieldObject;
+            protected readonly FieldObject fieldObject;
 
             /// <summary>
             /// Constructs a <see cref="FieldObjectBuilderFinal"/> to resume building of a <see cref="FieldObject"/>.
@@ -128,7 +128,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <param name="fieldObject"></param>
             public FieldObjectBuilderFinal(FieldObject fieldObject)
             {
-                _fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture)); ;
+                this.fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture)); ;
             }
             /// <summary>
             /// Sets the <see cref="FieldObject"/> to build as enabled.
@@ -136,7 +136,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public FieldObjectBuilderFinal Enabled()
             {
-                _fieldObject._enabled = "1";
+                fieldObject._enabled = "1";
                 return this;
             }
             /// <summary>
@@ -146,7 +146,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public FieldObjectBuilderFinal FieldValue(string fieldValue)
             {
-                _fieldObject.FieldValue = fieldValue;
+                fieldObject.FieldValue = fieldValue;
                 return this;
             }
             /// <summary>
@@ -155,7 +155,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public FieldObjectBuilderFinal Locked()
             {
-                _fieldObject._locked = "1";
+                fieldObject._locked = "1";
                 return this;
             }
             /// <summary>
@@ -165,7 +165,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public FieldObjectBuilderFinal Modified()
             {
-                _fieldObject._modified = true;
+                fieldObject._modified = true;
                 return this;
             }
             /// <summary>
@@ -174,14 +174,14 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public FieldObjectBuilderFinal Required()
             {
-                _fieldObject._required = "1";
+                fieldObject._required = "1";
                 return this;
             }
             /// <summary>
             /// Builds the <see cref="FieldObject"/> based on the supplied build parameters.
             /// </summary>
             /// <returns>A <see cref="FieldObject"/>.</returns>
-            public FieldObject Build() => _fieldObject;
+            public FieldObject Build() => fieldObject;
         }
 
         /// <summary>
@@ -189,16 +189,16 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         public class RowObjectFieldObjectBuilder
         {
-            protected readonly FieldObject _fieldObject;
-            protected readonly RowObject _rowObject;
+            protected readonly FieldObject fieldObject;
+            protected readonly RowObject rowObject;
 
             /// <summary>
             /// Constructs a FieldObjectBuilder with Enabled, Locked, and Required set to false by default.
             /// </summary>
             public RowObjectFieldObjectBuilder(RowObject rowObject)
             {
-                _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-                _fieldObject = new FieldObject();
+                this.rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                fieldObject = new FieldObject();
             }
             /// <summary>
             /// Constructs a FieldObjectBuilder to resume work on an existing <see cref="FieldObject"/>.
@@ -206,8 +206,8 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <param name="fieldObject"></param>
             protected RowObjectFieldObjectBuilder(FieldObject fieldObject, RowObject rowObject)
             {
-                _fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-                _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                this.fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                this.rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
             }
             /// <summary>
             /// Sets the FieldNumber for the FieldObject to build.
@@ -219,8 +219,8 @@ namespace RarelySimple.AvatarScriptLink.Objects
             {
                 if (string.IsNullOrEmpty(fieldNumber))
                     throw new ArgumentNullException(nameof(fieldNumber), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-                _fieldObject.FieldNumber = fieldNumber;
-                return new RowObjectFieldObjectBuilderFinal(_fieldObject, _rowObject);
+                fieldObject.FieldNumber = fieldNumber;
+                return new RowObjectFieldObjectBuilderFinal(fieldObject, rowObject);
             }
         }
         /// <summary>
@@ -228,16 +228,16 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         public class RowObjectFieldObjectBuilderFinal
         {
-            protected readonly FieldObject _fieldObject;
-            protected readonly RowObject _rowObject;
+            protected readonly FieldObject fieldObject;
+            protected readonly RowObject rowObject;
 
             /// <summary>
             /// Constructs a <see cref="FieldObjectBuilderFinal"/> to resume building of a <see cref="FieldObject"/>.
             /// </summary>
             /// <param name="fieldObject"></param>
             public RowObjectFieldObjectBuilderFinal(FieldObject fieldObject, RowObject rowObject) {
-                _fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-                _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                this.fieldObject = fieldObject ?? throw new ArgumentNullException(nameof(fieldObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                this.rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
             }
 
             /// <summary>
@@ -246,7 +246,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public RowObjectFieldObjectBuilderFinal Enabled()
             {
-                _fieldObject._enabled = "1";
+                fieldObject._enabled = "1";
                 return this;
             }
             /// <summary>
@@ -256,7 +256,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public RowObjectFieldObjectBuilderFinal FieldValue(string fieldValue)
             {
-                _fieldObject.FieldValue = fieldValue;
+                fieldObject.FieldValue = fieldValue;
                 return this;
             }
             /// <summary>
@@ -265,7 +265,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public RowObjectFieldObjectBuilderFinal Locked()
             {
-                _fieldObject._locked = "1";
+                fieldObject._locked = "1";
                 return this;
             }
             /// <summary>
@@ -275,7 +275,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public RowObjectFieldObjectBuilderFinal Modified()
             {
-                _fieldObject._modified = true;
+                fieldObject._modified = true;
                 return this;
             }
             /// <summary>
@@ -284,17 +284,17 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <returns>A <see cref="FieldObjectBuilderFinal"/> to resume build.</returns>
             public RowObjectFieldObjectBuilderFinal Required()
             {
-                _fieldObject._required = "1";
+                fieldObject._required = "1";
                 return this;
             }
             /// <summary>
             /// Builds the <see cref="FieldObject"/> based on the supplied build parameters.
             /// </summary>
             /// <returns>A <see cref="FieldObject"/>.</returns>
-            public RowObject.RowObjectBuilderFinal Add()
+            public RowObject.RowObjectBuilderFinal AddField()
             {
-                _rowObject.Fields.Add(_fieldObject);
-                return new RowObject.RowObjectBuilderFinal(_rowObject);
+                rowObject.Fields.Add(fieldObject);
+                return new RowObject.RowObjectBuilderFinal(rowObject);
             }
         }
     }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/FormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/FormObject.cs
@@ -1,6 +1,8 @@
-﻿using RarelySimple.AvatarScriptLink.Objects.Advanced;
-using RarelySimple.AvatarScriptLink.Helpers;
+﻿using RarelySimple.AvatarScriptLink.Helpers;
+using RarelySimple.AvatarScriptLink.Objects.Advanced;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace RarelySimple.AvatarScriptLink.Objects
 {
@@ -50,9 +52,35 @@ namespace RarelySimple.AvatarScriptLink.Objects
         public FormObject(string formId, RowObject currentRow, bool multipleIteration, List<RowObject> otherRows)
             : base(formId, currentRow, multipleIteration, otherRows)
         { }
-
-
-
+        /// <summary>
+        /// Initializes a <see cref="FormObject"/>
+        /// </summary>
+        /// <returns>A <see cref="FormObject"/></returns>
+        public static FormObject Initialize() { return new FormObject(); }
+        /// <summary>
+        /// Initializes a <see cref="FormObjectBuilder"/> to help construct a <see cref="FormObject"/>.
+        /// The implementation must set the FormId before build may be completed.
+        /// <code>
+        /// // Sample usage
+        /// // Assumes FieldObjects were created earlier
+        /// FormObject formObject = FormObject.Builder()
+        ///                                   .FormId("1")
+        ///                                   .CurrentRow()
+        ///                                       .RowId("1||1")
+        ///                                       .Field(fieldObject1)
+        ///                                       .Field(fieldObject2)
+        ///                                       .AddRow()
+        ///                                   .MultipleIteration()
+        ///                                   .OtherRow()
+        ///                                       .RowId("1||2")
+        ///                                       .Field(fieldObject3)
+        ///                                       .Field(fieldObject4)
+        ///                                       .AddRow()
+        ///                                   .Build();
+        /// </code>
+        /// </summary>
+        /// <returns>A <see cref="FormObject"/></returns>
+        public static FormObjectBuilder Builder() { return new FormObjectBuilder(); }
 
         /// <summary>
         /// Returns a deep copy of the <see cref="FormObject"/>.
@@ -75,5 +103,118 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         /// <returns><see cref="string"/> of all of the contents of the <see cref="FormObject"/> formatted as XML.</returns>
         public override string ToXml() => OptionObjectHelpers.TransformToXml(this);
+        /// <summary>
+        /// A Fluent Builder for constructing FormObjects
+        /// </summary>
+        public class FormObjectBuilder
+        {
+            protected readonly FormObject formObject;
+            /// <summary>
+            /// Constructs a FormObjectBuilder
+            /// </summary>
+            public FormObjectBuilder()
+            {
+                formObject = new FormObject();
+            }
+            /// <summary>
+            /// Sets the FormId of the <see cref="FormObject"/>.
+            /// This is required before any other attributes may be set on the <see cref="FormObject"/> built.
+            /// </summary>
+            /// <param name="formId">Required. The FormId to assign to the <see cref="FormObject"/></param>
+            /// <returns>A <see cref="FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public FormObjectBuilderFinal FormId(string formId)
+            {
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.FormId = formId;
+                return new FormObjectBuilderFinal(formObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a <see cref="FormObject"/> build.
+        /// </summary>
+        public class FormObjectBuilderFinal
+        {
+            protected readonly FormObject formObject;
+            /// <summary>
+            /// Constructs a FormObjectBuilderFinal used to complete the build of a <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="formObject">The <see cref="FormObject"/> to continue building.</param>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="FormObject"/> is provided for continuation of build.</exception>
+            public FormObjectBuilderFinal(FormObject formObject)
+            {
+                this.formObject = formObject ?? throw new ArgumentNullException(nameof(formObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Initializes a builder to construct the CurrentRow.
+            /// </summary>
+            /// <returns>A <see cref="RowObject.CurrentRowObjectBuilder"/></returns>
+            public RowObject.CurrentRowObjectBuilder CurrentRow()
+            {
+                return new RowObject.CurrentRowObjectBuilder(formObject);
+            }
+            /// <summary>
+            /// Sets the CurrentRow of the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to set as the CurrentRow.</param>
+            /// <returns>A <see cref=" FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public FormObjectBuilderFinal CurrentRow(RowObject rowObject)
+            {
+                formObject.CurrentRow = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                return this;
+            }
+            /// <summary>
+            /// Indicate the <see cref="FormObject"/> uses a Multiple-Iteration Table.
+            /// <para>Must be set to enable the adding of OtherRows to the <see cref="FormObject"/></para>
+            /// </summary>
+            /// <returns>A <see cref="FormObjectBuilderMIFinal"/></returns>
+            public FormObjectBuilderMIFinal MultipleIteration()
+            {
+                formObject.MultipleIteration = true;
+                return new FormObjectBuilderMIFinal(formObject);
+            }
+            /// <summary>
+            /// Builds the <see cref="FormObject"/> based on the supplied parameters.
+            /// </summary>
+            /// <returns>A <see cref="FormObject"/></returns>
+            public FormObject Build()
+            {
+                return formObject;
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a multiple iteration <see cref="FormObject"/> build.
+        /// </summary>
+        public class FormObjectBuilderMIFinal : FormObjectBuilderFinal
+        {
+            /// <summary>
+            /// Constructs a FormObjectBuilderMIFinal used to complete the build of a multiple iteration <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="formObject"></param>
+            public FormObjectBuilderMIFinal(FormObject formObject) : base(formObject) { }
+            /// <summary>
+            /// Initializes a builder to construct an OtherRow.
+            /// </summary>
+            /// <returns>A <see cref="RowObject.OtherRowObjectBuilder"/></returns>
+            public RowObject.OtherRowObjectBuilder OtherRow()
+            {
+                return new RowObject.OtherRowObjectBuilder(formObject);
+            }
+            /// <summary>
+            /// Adds another RowObject to the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to add.</param>
+            /// <returns>A <see cref="FormObjectBuilderMIFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public FormObjectBuilderMIFinal OtherRow(RowObject rowObject)
+            {
+                if (rowObject == null)
+                    throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.OtherRows.Add(rowObject);
+                return this;
+            }
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/RowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/RowObject.cs
@@ -72,11 +72,8 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// <summary>
         /// Initializes a <see cref="RowObject"/>
         /// </summary>
-        /// <returns>A <see cref="FieldObject"/></returns>
-        public static RowObject Initialize()
-        {
-            return new RowObject();
-        }
+        /// <returns>A <see cref="RowObject"/></returns>
+        public static RowObject Initialize() { return new RowObject(); }
 
         /// <summary>
         /// Initializes a <see cref="RowObjectBuilder"/> to help construct a <see cref="RowObject"/>.
@@ -87,16 +84,13 @@ namespace RarelySimple.AvatarScriptLink.Objects
         ///                                .RowId("1||2")
         ///                                .ParentRowId("1||1")
         ///                                .Field(fieldObject)
-        ///                                .Field().FieldNumber("123.45").FieldValue("Sample").Enabled().Add()
+        ///                                .Field().FieldNumber("123.45").FieldValue("Sample").Enabled().AddField()
         ///                                .Add()  // Sets RowAction to "ADD"
         ///                                .Build();
         /// </code>
         /// </summary>
-        /// <returns></returns>
-        public static RowObjectBuilder Builder()
-        {
-            return new RowObjectBuilder();
-        }
+        /// <returns>A <see cref="RowObject"/></returns>
+        public static RowObjectBuilder Builder() { return new RowObjectBuilder(); }
 
         /// <summary>
         /// Returns a deep copy of the <see cref="RowObject"/>.
@@ -161,8 +155,8 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <summary>
             /// Constructs a RowObjectBuilderFinal used to complete build of a <see cref="RowObject"/>.
             /// </summary>
-            /// <param name="rowObject"></param>
-            /// <exception cref="ArgumentNullException"></exception>
+            /// <param name="rowObject">The <see cref="RowObject"/> to continue building.</param>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> is provided for continuation of build.</exception>
             public RowObjectBuilderFinal(RowObject rowObject)
             {
                 _rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
@@ -233,6 +227,230 @@ namespace RarelySimple.AvatarScriptLink.Objects
             public RowObject Build()
             {
                 return _rowObject;
+            }
+        }
+        /// <summary>
+        /// A Fluent Builder for constructing a FormObject CurrentRow.
+        /// </summary>
+        public class CurrentRowObjectBuilder
+        {
+            protected readonly FormObject formObject;
+            protected readonly RowObject rowObject;
+            /// <summary>
+            /// Constructs a CurrentRowObjectBuilder with the RowAction set to None by default.
+            /// </summary>
+            public CurrentRowObjectBuilder(FormObject formObject)
+            {
+                this.formObject = formObject ?? throw new ArgumentNullException(nameof(formObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                rowObject = new RowObject()
+                {
+                    RowAction = ""
+                };
+            }
+            /// <summary>
+            /// Sets the RowId of the <see cref="RowObject"/> to build.
+            /// This is required before any other attributes may be set on the <see cref="RowObject"/> built.
+            /// </summary>
+            /// <param name="rowId">Required. The RowId assigned to the <see cref="RowObject"/></param>
+            /// <returns>A <see cref="CurrentRowObjectBuilderFinal"/> allowing for the setting of other attributes and building of the <see cref="RowObject"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public CurrentRowObjectBuilderFinal RowId(string rowId)
+            {
+                if (string.IsNullOrEmpty(rowId))
+                    throw new ArgumentNullException(nameof(rowId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                rowObject.RowId = rowId;
+                return new CurrentRowObjectBuilderFinal(rowObject, formObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a <see cref="RowObject"/> build.
+        /// </summary>
+        public class CurrentRowObjectBuilderFinal
+        {
+            protected readonly FormObject formObject;
+            protected readonly RowObject rowObject;
+
+            /// <summary>
+            /// Constructs a FormObjectRowObjectBuilderFinal used to complete build of a <see cref="RowObject"/>.
+            /// </summary>
+            /// <param name="rowObject"></param>
+            /// <exception cref="ArgumentNullException"></exception>
+            public CurrentRowObjectBuilderFinal(RowObject rowObject, FormObject formObject)
+            {
+                this.rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                this.formObject = formObject ?? throw new ArgumentNullException(nameof(formObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Sets the RowAction to Add for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public CurrentRowObjectBuilderFinal Add()
+            {
+                rowObject.RowAction = Objects.RowAction.Add;
+                return this;
+            }
+            /// <summary>
+            /// Sets the RowAction to Delete for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public CurrentRowObjectBuilderFinal Delete()
+            {
+                rowObject.RowAction = Objects.RowAction.Delete;
+                return this;
+            }
+            /// <summary>
+            /// Sets the RowAction to Edit for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public CurrentRowObjectBuilderFinal Edit()
+            {
+                rowObject.RowAction = Objects.RowAction.Edit;
+                return this;
+            }
+            /// <summary>
+            /// Sets the ParentRowId for this <see cref="RowObject"/>
+            /// </summary>
+            /// <param name="parentRowId">The RowId of the parent RowObject</param>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public CurrentRowObjectBuilderFinal ParentRowId(string parentRowId)
+            {
+                rowObject.ParentRowId = parentRowId;
+                return this;
+            }
+            /// <summary>
+            /// Adds a <see cref="FieldObject"/> to the <see cref="RowObject"/>
+            /// </summary>
+            /// <param name="fieldObject">The <see cref="FieldObject"/> to add</param>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public CurrentRowObjectBuilderFinal Field(FieldObject fieldObject)
+            {
+                if (rowObject.Fields == null)
+                {
+                    rowObject.Fields = new List<FieldObject>();
+                }
+                rowObject.Fields.Add(fieldObject);
+                return this;
+            }
+            /// <summary>
+            /// Builds the <see cref="RowObject"/> based on the supplied build parameters.
+            /// </summary>
+            /// <returns>A <see cref="RowObject"/></returns>
+            public FormObject.FormObjectBuilderFinal AddRow()
+            {
+                formObject.CurrentRow = rowObject;
+                return new FormObject.FormObjectBuilderFinal(formObject);
+            }
+        }
+        /// <summary>
+        /// A Fluent Builder for adding OtherRows to a <see cref="FormObject"/>
+        /// </summary>
+        public class OtherRowObjectBuilder
+        {
+            protected readonly FormObject formObject;
+            protected readonly RowObject rowObject;
+            /// <summary>
+            /// Constructs a FormObjectRowObjectBuilder with the RowAction set to None by default.
+            /// </summary>
+            public OtherRowObjectBuilder(FormObject formObject)
+            {
+                this.formObject = formObject ?? throw new ArgumentNullException(nameof(formObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                rowObject = new RowObject()
+                {
+                    RowAction = ""
+                };
+            }
+            /// <summary>
+            /// Sets the RowId of the <see cref="RowObject"/> to build.
+            /// This is required before any other attributes may be set on the <see cref="RowObject"/> built.
+            /// </summary>
+            /// <param name="rowId">Required. The RowId assigned to the <see cref="RowObject"/></param>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> allowing for the setting of other attributes and building of the <see cref="RowObject"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OtherRowObjectBuilderFinal RowId(string rowId)
+            {
+                if (string.IsNullOrEmpty(rowId))
+                    throw new ArgumentNullException(nameof(rowId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                rowObject.RowId = rowId;
+                return new OtherRowObjectBuilderFinal(rowObject, formObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a <see cref="RowObject"/> build.
+        /// </summary>
+        public class OtherRowObjectBuilderFinal
+        {
+            protected readonly FormObject formObject;
+            protected readonly RowObject rowObject;
+
+            /// <summary>
+            /// Constructs a FormObjectRowObjectBuilderFinal used to complete build of a <see cref="RowObject"/>.
+            /// </summary>
+            /// <param name="rowObject"></param>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OtherRowObjectBuilderFinal(RowObject rowObject, FormObject formObject)
+            {
+                this.rowObject = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                this.formObject = formObject ?? throw new ArgumentNullException(nameof(formObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Sets the RowAction to Add for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public OtherRowObjectBuilderFinal Add()
+            {
+                rowObject.RowAction = Objects.RowAction.Add;
+                return this;
+            }
+            /// <summary>
+            /// Sets the RowAction to Delete for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public OtherRowObjectBuilderFinal Delete()
+            {
+                rowObject.RowAction = Objects.RowAction.Delete;
+                return this;
+            }
+            /// <summary>
+            /// Sets the RowAction to Edit for this <see cref="RowObject"/>
+            /// </summary>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public OtherRowObjectBuilderFinal Edit()
+            {
+                rowObject.RowAction = Objects.RowAction.Edit;
+                return this;
+            }
+            /// <summary>
+            /// Sets the ParentRowId for this <see cref="RowObject"/>
+            /// </summary>
+            /// <param name="parentRowId">The RowId of the parent RowObject</param>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public OtherRowObjectBuilderFinal ParentRowId(string parentRowId)
+            {
+                rowObject.ParentRowId = parentRowId;
+                return this;
+            }
+            /// <summary>
+            /// Adds a <see cref="FieldObject"/> to the <see cref="RowObject"/>
+            /// </summary>
+            /// <param name="fieldObject">The <see cref="FieldObject"/> to add</param>
+            /// <returns>A <see cref="OtherRowObjectBuilderFinal"/> to resume build.</returns>
+            public OtherRowObjectBuilderFinal Field(FieldObject fieldObject)
+            {
+                if (rowObject.Fields == null)
+                {
+                    rowObject.Fields = new List<FieldObject>();
+                }
+                rowObject.Fields.Add(fieldObject);
+                return this;
+            }
+            /// <summary>
+            /// Builds the <see cref="RowObject"/> based on the supplied build parameters.
+            /// </summary>
+            /// <returns>A <see cref="RowObject"/></returns>
+            public FormObject.FormObjectBuilderMIFinal AddRow()
+            {
+                formObject.OtherRows.Add(rowObject);
+                return new FormObject.FormObjectBuilderMIFinal(formObject);
             }
         }
     }


### PR DESCRIPTION
This update introduces a fluent builder for FormObjects. This includes a nested/faceted builder for the CurrentRow and OtherRows or inserting a pre-defined RowObject. FieldObjects must be defined separately at this time. OtherRows may not be added until the FormObject is defined as MultipleIteration (false by default).

```cs
[TestMethod]
public void TestMethod1()
{
    var expected = "123";
    // FieldObject and RowObject definitions here 
    FormObject formObject = FormObject.Builder()
        .FormId(expected)
        .CurrentRow()
            .RowId("123||1")
            .Field(fieldObject1)
            .Field(fieldObject2)
            .AddRow()
        .MultipleIteration()
        .OtherRow()
            .RowId("123||2")
            .Field(fieldObject3)
            .Field(fieldObject4)
            .AddRow()
        .OtherRow(rowObject)
        .Build();
    Assert.AreEqual(expected, formObject.FormId);
}
```