### PR TITLE
Create OptionObject Faceted Fluent Builder

### DIFF
--- a/docs/docs/dotnet/data-model/optionobject.mdx
+++ b/docs/docs/dotnet/data-model/optionobject.mdx
@@ -117,7 +117,8 @@ The following methods are available on the OptionObject to assist with common ta
 | AddFormObject([FormObject](../formobject))     | Adds a [FormObject](../formobject) to the OptionObject.            |
 | AddFormObject(string, bool)                   | Creates a [FormObject](../formobject) with specified FormId and adds to the OptionObject2015. The second parameter specifies whether the [FormObject](../formobject) should be flagged as a Multiple Iteration form. |
 | AddRowObject(string, [RowObject](../rowobject))| Adds a [RowObject](../rowobject) to the [FormObject](../formobject) with the specified FormId. |
-| Clone                                         | Clones the OptionObject.            |
+| Builder() | Initializes a builder for constructing a OptionObject. |
+| Clone()                                        | Clones the OptionObject.            |
 | DeleteRowObject([RowObject](../rowobject))     | Marks a <see cref="RowObject"/> for deletion.            |
 | DeleteRowObject(string)                       | Marks a <see cref="RowObject"/> for deletion by specified RowId.            |
 | DisableAllFieldObjects()                      | Sets all [FieldObjects](../fieldobject) as disabled.            |
@@ -131,6 +132,7 @@ The following methods are available on the OptionObject to assist with common ta
 | GetHashCode()                                 | Overrides the GetHashCode method for a OptionObjectBase.            |
 | GetMultipleIterationStatus(string)            | Returns the Multiple Iteration Status of the form matching the FormId.            |
 | GetParentRowId(string)                        | Returns the CurrentRow ParentRowId of the form matching the FormId.            |
+| Initialize() | Initializes an empty OptionObject. |
 | IsFieldEnabled(string)                        | Returns whether the specified field is enabled.            |
 | IsFieldLocked(string)                         | Returns whether the specified field is locked.            |
 | IsFieldModified(string)                       | Returns whether the specified field is modified.            |

--- a/docs/docs/dotnet/data-model/optionobject2.mdx
+++ b/docs/docs/dotnet/data-model/optionobject2.mdx
@@ -122,7 +122,8 @@ The following methods are available on the OptionObject2 to assist with common t
 | AddFormObject([FormObject](../formobject))     | Adds a [FormObject](../formobject) to the OptionObject2.            |
 | AddFormObject(string, bool)                   | Creates a [FormObject](../formobject) with specified FormId and adds to the OptionObject2015. The second parameter specifies whether the [FormObject](../formobject) should be flagged as a Multiple Iteration form. |
 | AddRowObject(string, [RowObject](../rowobject))| Adds a [RowObject](../rowobject) to the [FormObject](../formobject) with the specified FormId. |
-| Clone                                         | Clones the OptionObject2.            |
+| Builder() | Initializes a builder for constructing a OptionObject2. |
+| Clone90                                        | Clones the OptionObject2.            |
 | DeleteRowObject([RowObject](../rowobject))     | Marks a [RowObject"](../rowobject) for deletion.            |
 | DeleteRowObject(string)                       | Marks a [RowObject"](../rowobject) for deletion by specified RowId.            |
 | DisableAllFieldObjects()                      | Sets all [FieldObjects](../fieldobject) as disabled.            |
@@ -136,6 +137,7 @@ The following methods are available on the OptionObject2 to assist with common t
 | GetHashCode()                                 | Overrides the GetHashCode method for a OptionObjectBase.            |
 | GetMultipleIterationStatus(string)            | Returns the Multiple Iteration Status of the form matching the FormId.            |
 | GetParentRowId(string)                        | Returns the CurrentRow ParentRowId of the form matching the FormId.            |
+| Initialize() | Initializes an empty OptionObject2. |
 | IsFieldEnabled(string)                        | Returns whether the specified field is enabled.            |
 | IsFieldLocked(string)                         | Returns whether the specified field is locked.            |
 | IsFieldModified(string)                       | Returns whether the specified field is modified.            |

--- a/docs/docs/dotnet/data-model/optionobject2015.mdx
+++ b/docs/docs/dotnet/data-model/optionobject2015.mdx
@@ -129,7 +129,8 @@ The following methods are available on the OptionObject2015 to assist with commo
 | AddFormObject([FormObject](../formobject))     | Adds a [FormObject](../formobject) to the OptionObject2015.            |
 | AddFormObject(string, bool)                   | Creates a [FormObject](../formobject) with specified FormId and adds to the OptionObject2015. The second parameter specifies whether the [FormObject](../formobject) should be flagged as a Multiple Iteration form. |
 | AddRowObject(string, [RowObject](../rowobject))| Adds a [RowObject](../rowobject) to the [FormObject](../formobject) with the specified FormId. |
-| Clone                                         | Clones the OptionObject2015.            |
+| Builder() | Initializes a builder for constructing a OptionObject2015. |
+| Clone()                                        | Clones the OptionObject2015.            |
 | DeleteRowObject([RowObject](../rowobject))     | Marks a <see cref="RowObject"/> for deletion.            |
 | DeleteRowObject(string)                       | Marks a <see cref="RowObject"/> for deletion by specified RowId.            |
 | DisableAllFieldObjects()                      | Sets all [FieldObjects](../fieldobject) as disabled.            |
@@ -143,6 +144,7 @@ The following methods are available on the OptionObject2015 to assist with commo
 | GetHashCode()                                 | Overrides the GetHashCode method for a OptionObjectBase.            |
 | GetMultipleIterationStatus(string)            | Returns the Multiple Iteration Status of the form matching the FormId.            |
 | GetParentRowId(string)                        | Returns the CurrentRow ParentRowId of the form matching the FormId.            |
+| Initialize() | Initializes an empty OptionObject2015. |
 | IsFieldEnabled(string)                        | Returns whether the specified field is enabled.            |
 | IsFieldLocked(string)                         | Returns whether the specified field is locked.            |
 | IsFieldModified(string)                       | Returns whether the specified field is modified.            |

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2015Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2015Tests.cs
@@ -13,63 +13,59 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestInitialize]
         public void TestInitialize()
         {
-            this.configuredOptionObject2015 = new OptionObject2015();
+            configuredOptionObject2015 = new OptionObject2015();
+            // First Form
+            FieldObject fieldObject = FieldObject.Builder()
+                                                 .FieldNumber("123")
+                                                 .FieldValue("Value")
+                                                 .Enabled()
+                                                 .Locked()
+                                                 .Required()
+                                                 .Build();
 
-            FieldObject addField = new FieldObject
-            {
-                FieldNumber = "123",
-                FieldValue = "Value",
-                Enabled = "1",
-                Lock = "1",
-                Required = "1"
-            };
-            RowObject addRow = new RowObject
-            {
-                RowId = "1||1"
-            };
-            addRow.Fields.Add(addField);
-            FormObject addForm = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = addRow
-            };
-            configuredOptionObject2015.Forms.Add(addForm);
+            FormObject formObject = FormObject.Builder()
+                                              .FormId("1")
+                                              .CurrentRow()
+                                                    .RowId("1||1")
+                                                    .Field(fieldObject)
+                                                    .AddRow()
+                                              .Build();
+            // Second Form
+            RowObject rowObject01 = RowObject.Builder()
+                                           .RowId("2||1")
+                                           .Field()
+                                                .FieldNumber("234")
+                                                .FieldValue("MI Value")
+                                                .AddField()
+                                           .Build();
 
-            FieldObject addMiField01 = new FieldObject
-            {
-                FieldNumber = "234",
-                FieldValue = "MI Value"
-            };
-            FieldObject addMiField02 = new FieldObject
-            {
-                FieldNumber = "234",
-                FieldValue = "MI Value 2"
-            };
-            RowObject addMiRow01 = new RowObject
-            {
-                RowId = "2||1"
-            };
-            addMiRow01.Fields.Add(addMiField01);
-            RowObject addMiRow02 = new RowObject
-            {
-                RowId = "2||2"
-            };
-            addMiRow02.Fields.Add(addMiField01);
-            FormObject addMiForm = new FormObject
-            {
-                FormId = "2",
-                CurrentRow = addMiRow01,
-                MultipleIteration = true
-            };
-            addMiForm.OtherRows.Add(addMiRow02);
-            configuredOptionObject2015.Forms.Add(addMiForm);
+            RowObject rowObject02 = RowObject.Builder()
+                                           .RowId("2||2")
+                                           .Field()
+                                                .FieldNumber("234")
+                                                .FieldValue("MI Value 2")
+                                                .AddField()
+                                           .Build();
+
+            FormObject miFormObject = FormObject.Builder()
+                                                .FormId("2")
+                                                .CurrentRow(rowObject01)
+                                                .MultipleIteration()
+                                                .OtherRow(rowObject02)
+                                                .Build();
+
+            configuredOptionObject2015 = OptionObject2015.Builder()
+                                                         .OptionId("OPT1234")
+                                                         .Form(formObject)
+                                                         .Form(miFormObject)
+                                                         .Build();
         }
 
         [TestMethod]
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_HasFormObject()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             Assert.IsNotNull(optionObject.Forms);
         }
 
@@ -77,7 +73,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_Forms_IsNotEmpty()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             var expected = new List<FormObject>();
             var actual = optionObject.Forms;
             Assert.AreNotEqual(expected, actual);
@@ -87,7 +83,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_CanGetHtmlString_WithoutHtmlHeaders()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             var actual = optionObject.ToHtmlString(false);
             Assert.IsNotNull(actual);
         }
@@ -96,8 +92,8 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_CanGetHtmlString_WithHtmlHeaders()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
-            var actual = optionObject.ToHtmlString(false);
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
+            var actual = optionObject.ToHtmlString(true);
             Assert.IsNotNull(actual);
         }
 
@@ -105,17 +101,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_AddFormObject_FormObject()
         {
-            FormObject formObject1 = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            FormObject formObject2 = new FormObject
-            {
-                FormId = "2",
-                MultipleIteration = true
-            };
-            OptionObject2015 optionObject = new OptionObject2015();
+            FormObject formObject1 = FormObject.Builder()
+                                               .FormId("1")
+                                               .Build();
+            FormObject formObject2 = FormObject.Builder()
+                                               .FormId("2")
+                                               .MultipleIteration()
+                                               .Build();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             optionObject.AddFormObject(formObject1);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject(formObject2);
@@ -127,17 +120,8 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2015_AddFormObject_FormObject_Exception()
         {
-            FormObject formObject1 = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            FormObject formObject2 = new FormObject
-            {
-                FormId = "2",
-                MultipleIteration = true
-            };
-            OptionObject2015 optionObject = new OptionObject2015();
+            FormObject formObject1 = FormObject.Builder().FormId("1").Build();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             optionObject.AddFormObject(formObject1);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject(formObject1);
@@ -148,7 +132,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_AddFormObject_Properties()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             optionObject.AddFormObject("1", false);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject("2", true);
@@ -160,7 +144,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2015_AddFormObject_Properties_Exception()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             optionObject.AddFormObject("1", false);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject("1", false);
@@ -172,7 +156,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2015_GetCurrentRowId_Error()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             var actual = optionObject.GetCurrentRowId("1");
             Assert.AreEqual(null, actual);
         }
@@ -181,17 +165,16 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_GetCurrentRowId_AreEqual()
         {
-            RowObject rowObject = new RowObject
-            {
-                RowId = "1||1"
-            };
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = rowObject
-            };
-            OptionObject2015 optionObject = new OptionObject2015();
-            optionObject.Forms.Add(formObject);
+            FormObject formObject = FormObject.Builder()
+                                              .FormId("1")
+                                              .CurrentRow()
+                                                    .RowId("1||1")
+                                                    .AddRow()
+                                              .Build();
+            OptionObject2015 optionObject = OptionObject2015.Builder()
+                                                            .OptionId("OPT1234")
+                                                            .Form(formObject)
+                                                            .Build();
             var actual = optionObject.GetCurrentRowId("1");
             Assert.AreEqual("1||1", actual);
         }
@@ -210,7 +193,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2015_GetFieldValue_AreNotEqual()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             var expected = "Value";
             var actual = optionObject.GetFieldValue("123");
             Assert.AreNotEqual(expected, actual);
@@ -269,14 +252,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_GetMultipleIterationStatus_IsFalse()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            optionObject.Forms.Add(formObject);
-            var actual = optionObject.GetMultipleIterationStatus("1");
+            string formId = "1";
+            OptionObject2015 optionObject = OptionObject2015.Builder()
+                                                            .OptionId("OPT1234")
+                                                            .Form()
+                                                                .FormId(formId)
+                                                                .AddForm()
+                                                            .Build();
+            var actual = optionObject.GetMultipleIterationStatus(formId);
             Assert.IsFalse(actual);
         }
 
@@ -285,7 +268,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2015_GetMultipleIterationStatus_IsNotFound()
         {
-            OptionObject2015 optionObject = new OptionObject2015();
+            OptionObject2015 optionObject = OptionObject2015.Initialize();
             var actual = optionObject.GetMultipleIterationStatus("1");
             Assert.IsFalse(actual);
         }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2015Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2015Tests.cs
@@ -13,7 +13,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestInitialize]
         public void TestInitialize()
         {
-            configuredOptionObject2015 = new OptionObject2015();
+            configuredOptionObject2015 = OptionObject2015.Initialize();
             // First Form
             FieldObject fieldObject = FieldObject.Builder()
                                                  .FieldNumber("123")
@@ -32,20 +32,20 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
                                               .Build();
             // Second Form
             RowObject rowObject01 = RowObject.Builder()
-                                           .RowId("2||1")
-                                           .Field()
-                                                .FieldNumber("234")
-                                                .FieldValue("MI Value")
-                                                .AddField()
-                                           .Build();
+                                             .RowId("2||1")
+                                             .Field()
+                                                 .FieldNumber("234")
+                                                 .FieldValue("MI Value")
+                                                 .AddField()
+                                             .Build();
 
             RowObject rowObject02 = RowObject.Builder()
-                                           .RowId("2||2")
-                                           .Field()
-                                                .FieldNumber("234")
-                                                .FieldValue("MI Value 2")
-                                                .AddField()
-                                           .Build();
+                                             .RowId("2||2")
+                                             .Field()
+                                                 .FieldNumber("234")
+                                                 .FieldValue("MI Value 2")
+                                                 .AddField()
+                                             .Build();
 
             FormObject miFormObject = FormObject.Builder()
                                                 .FormId("2")
@@ -295,17 +295,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2015")]
         public void OptionObject2015_GetParentRowId_AreEqual()
         {
-            RowObject rowObject = new RowObject
-            {
-                ParentRowId = "1||1"
-            };
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = rowObject
-            };
-            OptionObject2015 optionObject = new OptionObject2015();
-            optionObject.Forms.Add(formObject);
+            RowObject rowObject = RowObject.Builder().RowId("1||2").ParentRowId("1||1").Build();
+            OptionObject2015 optionObject = OptionObject2015.Builder()
+                                                            .OptionId("USER00")
+                                                            .Form()
+                                                                .FormId("1")
+                                                                .CurrentRow(rowObject)
+                                                                .AddForm()
+                                                            .Build();
             var actual = optionObject.GetParentRowId("1");
             Assert.AreEqual(rowObject.ParentRowId, actual);
         }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2Tests.cs
@@ -13,63 +13,59 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestInitialize]
         public void TestInitialize()
         {
-            this.configuredOptionObject2 = new OptionObject2();
+            configuredOptionObject2 = OptionObject2.Initialize();
+            // First Form
+            FieldObject fieldObject = FieldObject.Builder()
+                                                 .FieldNumber("123")
+                                                 .FieldValue("Value")
+                                                 .Enabled()
+                                                 .Locked()
+                                                 .Required()
+                                                 .Build();
 
-            FieldObject addField = new FieldObject
-            {
-                FieldNumber = "123",
-                FieldValue = "Value",
-                Enabled = "1",
-                Lock = "1",
-                Required = "1"
-            };
-            RowObject addRow = new RowObject
-            {
-                RowId = "1||1"
-            };
-            addRow.Fields.Add(addField);
-            FormObject addForm = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = addRow
-            };
-            configuredOptionObject2.Forms.Add(addForm);
+            FormObject formObject = FormObject.Builder()
+                                              .FormId("1")
+                                              .CurrentRow()
+                                                    .RowId("1||1")
+                                                    .Field(fieldObject)
+                                                    .AddRow()
+                                              .Build();
+            // Second Form
+            RowObject rowObject01 = RowObject.Builder()
+                                             .RowId("2||1")
+                                             .Field()
+                                                 .FieldNumber("234")
+                                                 .FieldValue("MI Value")
+                                                 .AddField()
+                                             .Build();
 
-            FieldObject addMiField01 = new FieldObject
-            {
-                FieldNumber = "234",
-                FieldValue = "MI Value"
-            };
-            FieldObject addMiField02 = new FieldObject
-            {
-                FieldNumber = "234",
-                FieldValue = "MI Value 2"
-            };
-            RowObject addMiRow01 = new RowObject
-            {
-                RowId = "2||1"
-            };
-            addMiRow01.Fields.Add(addMiField01);
-            RowObject addMiRow02 = new RowObject
-            {
-                RowId = "2||2"
-            };
-            addMiRow02.Fields.Add(addMiField01);
-            FormObject addMiForm = new FormObject
-            {
-                FormId = "2",
-                CurrentRow = addMiRow01,
-                MultipleIteration = true
-            };
-            addMiForm.OtherRows.Add(addMiRow02);
-            configuredOptionObject2.Forms.Add(addMiForm);
+            RowObject rowObject02 = RowObject.Builder()
+                                             .RowId("2||2")
+                                             .Field()
+                                                 .FieldNumber("234")
+                                                 .FieldValue("MI Value 2")
+                                                 .AddField()
+                                             .Build();
+
+            FormObject miFormObject = FormObject.Builder()
+                                                .FormId("2")
+                                                .CurrentRow(rowObject01)
+                                                .MultipleIteration()
+                                                .OtherRow(rowObject02)
+                                                .Build();
+
+            configuredOptionObject2 = OptionObject2.Builder()
+                                                   .OptionId("OPT1234")
+                                                   .Form(formObject)
+                                                   .Form(miFormObject)
+                                                   .Build();
         }
 
         [TestMethod]
         [TestCategory("OptionObject2")]
         public void OptionObject2_HasFormObject()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             Assert.IsNotNull(optionObject.Forms);
         }
 
@@ -77,7 +73,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_Forms_IsNotEmpty()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             var expected = new List<FormObject>();
             var actual = optionObject.Forms;
             Assert.AreNotEqual(expected, actual);
@@ -87,7 +83,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_CanGetHtmlString_WithoutHtmlHeaders()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             var actual = optionObject.ToHtmlString(false);
             Assert.IsNotNull(actual);
         }
@@ -96,7 +92,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_CanGetHtmlString_WithHtmlHeaders()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             var actual = optionObject.ToHtmlString(false);
             Assert.IsNotNull(actual);
         }
@@ -105,17 +101,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_AddFormObject_FormObject()
         {
-            FormObject formObject1 = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            FormObject formObject2 = new FormObject
-            {
-                FormId = "2",
-                MultipleIteration = true
-            };
-            OptionObject2 optionObject = new OptionObject2();
+            FormObject formObject1 = FormObject.Builder()
+                                               .FormId("1")
+                                               .Build();
+            FormObject formObject2 = FormObject.Builder()
+                                               .FormId("2")
+                                               .MultipleIteration()
+                                               .Build();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             optionObject.AddFormObject(formObject1);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject(formObject2);
@@ -127,17 +120,8 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2_AddFormObject_FormObject_Exception()
         {
-            FormObject formObject1 = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            FormObject formObject2 = new FormObject
-            {
-                FormId = "2",
-                MultipleIteration = true
-            };
-            OptionObject2 optionObject = new OptionObject2();
+            FormObject formObject1 = FormObject.Builder().FormId("1").Build();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             optionObject.AddFormObject(formObject1);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject(formObject1);
@@ -148,7 +132,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_AddFormObject_Properties()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             optionObject.AddFormObject("1", false);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject("2", true);
@@ -160,7 +144,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2_AddFormObject_Properties_Exception()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             optionObject.AddFormObject("1", false);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject("1", false);
@@ -172,7 +156,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2_GetCurrentRowId_Error()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             var actual = optionObject.GetCurrentRowId("1");
             Assert.AreEqual(null, actual);
         }
@@ -181,17 +165,16 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_GetCurrentRowId_AreEqual()
         {
-            RowObject rowObject = new RowObject
-            {
-                RowId = "1||1"
-            };
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = rowObject
-            };
-            OptionObject2 optionObject = new OptionObject2();
-            optionObject.Forms.Add(formObject);
+            FormObject formObject = FormObject.Builder()
+                                              .FormId("1")
+                                              .CurrentRow()
+                                                    .RowId("1||1")
+                                                    .AddRow()
+                                              .Build();
+            OptionObject2 optionObject = OptionObject2.Builder()
+                                                      .OptionId("OPT1234")
+                                                      .Form(formObject)
+                                                      .Build();
             var actual = optionObject.GetCurrentRowId("1");
             Assert.AreEqual("1||1", actual);
         }
@@ -210,7 +193,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2_GetFieldValue_AreNotEqual()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             var expected = "Value";
             var actual = optionObject.GetFieldValue("123");
             Assert.AreNotEqual(expected, actual);
@@ -269,13 +252,13 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_GetMultipleIterationStatus_IsFalse()
         {
-            OptionObject2 optionObject = new OptionObject2();
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            optionObject.Forms.Add(formObject);
+            string formId = "1";
+            OptionObject2 optionObject = OptionObject2.Builder()
+                                                      .OptionId("OPT1234")
+                                                      .Form()
+                                                          .FormId(formId)
+                                                          .AddForm()
+                                                      .Build();
             var actual = optionObject.GetMultipleIterationStatus("1");
             Assert.IsFalse(actual);
         }
@@ -285,7 +268,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2_GetMultipleIterationStatus_IsNotFound()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             var actual = optionObject.GetMultipleIterationStatus("1");
             Assert.IsFalse(actual);
         }
@@ -303,7 +286,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject2_GetParentRowId_Error()
         {
-            OptionObject2 optionObject = new OptionObject2();
+            OptionObject2 optionObject = OptionObject2.Initialize();
             var actual = optionObject.GetParentRowId("1");
             Assert.AreEqual(null, actual);
         }
@@ -312,17 +295,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject2")]
         public void OptionObject2_GetParentRowId_AreEqual()
         {
-            RowObject rowObject = new RowObject
-            {
-                ParentRowId = "1||1"
-            };
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = rowObject
-            };
-            OptionObject2 optionObject = new OptionObject2();
-            optionObject.Forms.Add(formObject);
+            RowObject rowObject = RowObject.Builder().RowId("1||2").ParentRowId("1||1").Build();
+            OptionObject2 optionObject = OptionObject2.Builder()
+                                                      .OptionId("USER00")
+                                                      .Form()
+                                                          .FormId("1")
+                                                          .CurrentRow(rowObject)
+                                                          .AddForm()
+                                                      .Build();
             var actual = optionObject.GetParentRowId("1");
             Assert.AreEqual(rowObject.ParentRowId, actual);
         }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObjectTests.cs
@@ -13,63 +13,59 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestInitialize]
         public void TestInitialize()
         {
-            this.configuredOptionObject = new OptionObject();
+            configuredOptionObject = OptionObject.Initialize();
+            // First Form
+            FieldObject fieldObject = FieldObject.Builder()
+                                                 .FieldNumber("123")
+                                                 .FieldValue("Value")
+                                                 .Enabled()
+                                                 .Locked()
+                                                 .Required()
+                                                 .Build();
 
-            FieldObject addField = new FieldObject
-            {
-                FieldNumber = "123",
-                FieldValue = "Value",
-                Enabled = "1",
-                Lock = "1",
-                Required = "1"
-            };
-            RowObject addRow = new RowObject
-            {
-                RowId = "1||1"
-            };
-            addRow.Fields.Add(addField);
-            FormObject addForm = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = addRow
-            };
-            configuredOptionObject.Forms.Add(addForm);
+            FormObject formObject = FormObject.Builder()
+                                              .FormId("1")
+                                              .CurrentRow()
+                                                    .RowId("1||1")
+                                                    .Field(fieldObject)
+                                                    .AddRow()
+                                              .Build();
+            // Second Form
+            RowObject rowObject01 = RowObject.Builder()
+                                             .RowId("2||1")
+                                             .Field()
+                                                 .FieldNumber("234")
+                                                 .FieldValue("MI Value")
+                                                 .AddField()
+                                             .Build();
 
-            FieldObject addMiField01 = new FieldObject
-            {
-                FieldNumber = "234",
-                FieldValue = "MI Value"
-            };
-            FieldObject addMiField02 = new FieldObject
-            {
-                FieldNumber = "234",
-                FieldValue = "MI Value 2"
-            };
-            RowObject addMiRow01 = new RowObject
-            {
-                RowId = "2||1"
-            };
-            addMiRow01.Fields.Add(addMiField01);
-            RowObject addMiRow02 = new RowObject
-            {
-                RowId = "2||2"
-            };
-            addMiRow02.Fields.Add(addMiField02);
-            FormObject addMiForm = new FormObject
-            {
-                FormId = "2",
-                CurrentRow = addMiRow01,
-                MultipleIteration = true
-            };
-            addMiForm.OtherRows.Add(addMiRow02);
-            configuredOptionObject.Forms.Add(addMiForm);
+            RowObject rowObject02 = RowObject.Builder()
+                                             .RowId("2||2")
+                                             .Field()
+                                                 .FieldNumber("234")
+                                                 .FieldValue("MI Value 2")
+                                                 .AddField()
+                                             .Build();
+
+            FormObject miFormObject = FormObject.Builder()
+                                                .FormId("2")
+                                                .CurrentRow(rowObject01)
+                                                .MultipleIteration()
+                                                .OtherRow(rowObject02)
+                                                .Build();
+
+            configuredOptionObject = OptionObject.Builder()
+                                                 .OptionId("OPT1234")
+                                                 .Form(formObject)
+                                                 .Form(miFormObject)
+                                                 .Build();
         }
 
         [TestMethod]
         [TestCategory("OptionObject")]
         public void OptionObject_HasFormObject()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             Assert.IsNotNull(optionObject.Forms);
         }
 
@@ -77,7 +73,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_Forms_IsNotEmpty()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             var expected = new List<FormObject>();
             var actual = optionObject.Forms;
             Assert.AreNotEqual(expected, actual);
@@ -87,7 +83,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_CanGetHtmlString_WithoutHtmlHeaders()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             var actual = optionObject.ToHtmlString(false);
             Assert.IsNotNull(actual);
         }
@@ -96,7 +92,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_CanGetHtmlString_WithHtmlHeaders()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             var actual = optionObject.ToHtmlString(false);
             Assert.IsNotNull(actual);
         }
@@ -105,17 +101,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_AddFormObject_FormObject()
         {
-            FormObject formObject1 = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            FormObject formObject2 = new FormObject
-            {
-                FormId = "2",
-                MultipleIteration = true
-            };
-            OptionObject optionObject = new OptionObject();
+            FormObject formObject1 = FormObject.Builder()
+                                               .FormId("1")
+                                               .Build();
+            FormObject formObject2 = FormObject.Builder()
+                                               .FormId("2")
+                                               .MultipleIteration()
+                                               .Build();
+            OptionObject optionObject = OptionObject.Initialize();
             optionObject.AddFormObject(formObject1);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject(formObject2);
@@ -127,17 +120,8 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject_AddFormObject_FormObject_Exception()
         {
-            FormObject formObject1 = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            FormObject formObject2 = new FormObject
-            {
-                FormId = "2",
-                MultipleIteration = true
-            };
-            OptionObject optionObject = new OptionObject();
+            FormObject formObject1 = FormObject.Builder().FormId("1").Build();
+            OptionObject optionObject = OptionObject.Initialize();
             optionObject.AddFormObject(formObject1);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject(formObject1);
@@ -148,7 +132,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_AddFormObject_Properties()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             optionObject.AddFormObject("1", false);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject("2", true);
@@ -160,7 +144,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject_AddFormObject_Properties_Exception()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             optionObject.AddFormObject("1", false);
             Assert.AreEqual(1, optionObject.Forms.Count);
             optionObject.AddFormObject("1", false);
@@ -172,7 +156,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject_GetCurrentRowId_Error()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             var actual = optionObject.GetCurrentRowId("1");
             Assert.AreEqual(null, actual);
         }
@@ -181,17 +165,16 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_GetCurrentRowId_AreEqual()
         {
-            RowObject rowObject = new RowObject
-            {
-                RowId = "1||1"
-            };
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = rowObject
-            };
-            OptionObject optionObject = new OptionObject();
-            optionObject.Forms.Add(formObject);
+            FormObject formObject = FormObject.Builder()
+                                              .FormId("1")
+                                              .CurrentRow()
+                                                    .RowId("1||1")
+                                                    .AddRow()
+                                              .Build();
+            OptionObject optionObject = OptionObject.Builder()
+                                                    .OptionId("OPT1234")
+                                                    .Form(formObject)
+                                                    .Build();
             var actual = optionObject.GetCurrentRowId("1");
             Assert.AreEqual("1||1", actual);
         }
@@ -210,7 +193,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject_GetFieldValue_AreNotEqual()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             var expected = "Value";
             var actual = optionObject.GetFieldValue("123");
             Assert.AreNotEqual(expected, actual);
@@ -269,13 +252,13 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_GetMultipleIterationStatus_IsFalse()
         {
-            OptionObject optionObject = new OptionObject();
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                MultipleIteration = false
-            };
-            optionObject.Forms.Add(formObject);
+            string formId = "1";
+            OptionObject optionObject = OptionObject.Builder()
+                                                    .OptionId("OPT1234")
+                                                    .Form()
+                                                        .FormId(formId)
+                                                        .AddForm()
+                                                    .Build();
             var actual = optionObject.GetMultipleIterationStatus("1");
             Assert.IsFalse(actual);
         }
@@ -285,7 +268,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject_GetMultipleIterationStatus_IsNotFound()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             var actual = optionObject.GetMultipleIterationStatus("1");
             Assert.IsFalse(actual);
         }
@@ -303,7 +286,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [ExpectedException(typeof(System.ArgumentException))]
         public void OptionObject_GetParentRowId_Error()
         {
-            OptionObject optionObject = new OptionObject();
+            OptionObject optionObject = OptionObject.Initialize();
             var actual = optionObject.GetParentRowId("1");
             Assert.AreEqual(null, actual);
         }
@@ -312,17 +295,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
         [TestCategory("OptionObject")]
         public void OptionObject_GetParentRowId_AreEqual()
         {
-            RowObject rowObject = new RowObject
-            {
-                ParentRowId = "1||1"
-            };
-            FormObject formObject = new FormObject
-            {
-                FormId = "1",
-                CurrentRow = rowObject
-            };
-            OptionObject optionObject = new OptionObject();
-            optionObject.Forms.Add(formObject);
+            RowObject rowObject = RowObject.Builder().RowId("1||2").ParentRowId("1||1").Build();
+            OptionObject optionObject = OptionObject.Builder()
+                                                    .OptionId("USER00")
+                                                    .Form()
+                                                        .FormId("1")
+                                                        .CurrentRow(rowObject)
+                                                        .AddForm()
+                                                    .Build();
             var actual = optionObject.GetParentRowId("1");
             Assert.AreEqual(rowObject.ParentRowId, actual);
         }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/FormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/FormObject.cs
@@ -216,5 +216,43 @@ namespace RarelySimple.AvatarScriptLink.Objects
                 return this;
             }
         }
+
+        public class OptionObjectFormObjectBuilder
+        {
+            protected readonly OptionObject2015 optionObject;
+            protected readonly FormObject formObject;
+
+            public OptionObjectFormObjectBuilder(OptionObject2015 optionObject)
+            {
+                this.optionObject = optionObject;
+                formObject = new FormObject();
+            }
+
+            public OptionObjectFormObjectBuilderFinal FormId(string formId)
+            {
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.FormId = formId;
+                return new OptionObjectFormObjectBuilderFinal(optionObject, formObject);
+            }
+        }
+
+        public class OptionObjectFormObjectBuilderFinal
+        {
+            protected readonly OptionObject2015 optionObject;
+            protected readonly FormObject formObject;
+
+            public OptionObjectFormObjectBuilderFinal(OptionObject2015 optionObject, FormObject formObject)
+            {
+                this.optionObject = optionObject;
+                this.formObject = formObject;
+            }
+
+            public OptionObject2015.OptionObject2015BuilderFinal AddForm()
+            {
+                optionObject.AddFormObject(formObject);
+                return new OptionObject2015.OptionObject2015BuilderFinal(optionObject);
+            }
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/FormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/FormObject.cs
@@ -216,18 +216,29 @@ namespace RarelySimple.AvatarScriptLink.Objects
                 return this;
             }
         }
-
+        /// <summary>
+        /// A Faceted Fluent Builder for adding FormObjects to OptionObjects
+        /// </summary>
         public class OptionObjectFormObjectBuilder
         {
-            protected readonly OptionObject2015 optionObject;
+            protected readonly OptionObject optionObject;
             protected readonly FormObject formObject;
-
-            public OptionObjectFormObjectBuilder(OptionObject2015 optionObject)
+            /// <summary>
+            /// Constructs a OptionObjectFormObjectBuilder
+            /// </summary>
+            /// <param name="optionObject"></param>
+            public OptionObjectFormObjectBuilder(OptionObject optionObject)
             {
                 this.optionObject = optionObject;
                 formObject = new FormObject();
             }
-
+            /// <summary>
+            /// Sets the FormId of the <see cref="FormObject"/>.
+            /// This is required before any other attributes may be set on the <see cref="FormObject"/> built.
+            /// </summary>
+            /// <param name="formId">Required. The FormId to assign to the <see cref="FormObject"/></param>
+            /// <returns>A <see cref="OptionObject2015FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
             public OptionObjectFormObjectBuilderFinal FormId(string formId)
             {
                 if (string.IsNullOrEmpty(formId))
@@ -236,22 +247,270 @@ namespace RarelySimple.AvatarScriptLink.Objects
                 return new OptionObjectFormObjectBuilderFinal(optionObject, formObject);
             }
         }
-
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a <see cref="FormObject"/> build.
+        /// </summary>
         public class OptionObjectFormObjectBuilderFinal
         {
-            protected readonly OptionObject2015 optionObject;
+            protected readonly OptionObject optionObject;
             protected readonly FormObject formObject;
-
-            public OptionObjectFormObjectBuilderFinal(OptionObject2015 optionObject, FormObject formObject)
+            /// <summary>
+            /// Constructs a OptionObjectFormObjectBuilderFinal used to add a FormObject to a OptionObject
+            /// </summary>
+            /// <param name="optionObject">The <see cref="OptionObject"/> to add <see cref="FormObject"/>.</param>
+            /// <param name="formObject">The <see cref="FormObject"/> to complete.</param>
+            public OptionObjectFormObjectBuilderFinal(OptionObject optionObject, FormObject formObject)
             {
                 this.optionObject = optionObject;
                 this.formObject = formObject;
             }
-
+            /// <summary>
+            /// Sets the CurrentRow of the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to set as the CurrentRow.</param>
+            /// <returns>A <see cref=" OptionObject2015FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public OptionObjectFormObjectBuilderFinal CurrentRow(RowObject rowObject)
+            {
+                formObject.CurrentRow = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                return this;
+            }
+            /// <summary>
+            /// Indicate the <see cref="FormObject"/> uses a Multiple-Iteration Table.
+            /// <para>Must be set to enable the adding of OtherRows to the <see cref="FormObject"/></para>
+            /// </summary>
+            /// <returns>A <see cref="OptionObjectFormObjectBuilderMIFinal"/></returns>
+            public OptionObjectFormObjectBuilderMIFinal MultipleIteration()
+            {
+                formObject.MultipleIteration = true;
+                return new OptionObjectFormObjectBuilderMIFinal(optionObject, formObject);
+            }
+            /// <summary>
+            /// Adds FormObject to the <see cref="OptionObject"/>.
+            /// </summary>
+            /// <returns>A <see cref="OptionObjectBuilderFinal"/></returns>
+            public OptionObject.OptionObjectBuilderFinal AddForm()
+            {
+                optionObject.AddFormObject(formObject);
+                return new OptionObject.OptionObjectBuilderFinal(optionObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a multiple iteration <see cref="FormObject"/> build.
+        /// </summary>
+        public class OptionObjectFormObjectBuilderMIFinal : OptionObjectFormObjectBuilderFinal
+        {
+            public OptionObjectFormObjectBuilderMIFinal(OptionObject optionObject, FormObject formObject) : base(optionObject, formObject) { }
+            /// <summary>
+            /// Adds another RowObject to the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to add.</param>
+            /// <returns>A <see cref="OptionObjectFormObjectBuilderMIFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public OptionObjectFormObjectBuilderMIFinal OtherRow(RowObject rowObject)
+            {
+                if (rowObject == null)
+                    throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.OtherRows.Add(rowObject);
+                return this;
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for adding FormObjects to OptionObject2s
+        /// </summary>
+        public class OptionObject2FormObjectBuilder
+        {
+            protected readonly OptionObject2 optionObject;
+            protected readonly FormObject formObject;
+            /// <summary>
+            /// Constructs a OptionObject2FormObjectBuilder
+            /// </summary>
+            /// <param name="optionObject"></param>
+            public OptionObject2FormObjectBuilder(OptionObject2 optionObject)
+            {
+                this.optionObject = optionObject;
+                formObject = new FormObject();
+            }
+            /// <summary>
+            /// Sets the FormId of the <see cref="FormObject"/>.
+            /// This is required before any other attributes may be set on the <see cref="FormObject"/> built.
+            /// </summary>
+            /// <param name="formId">Required. The FormId to assign to the <see cref="FormObject"/></param>
+            /// <returns>A <see cref="OptionObject2015FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2FormObjectBuilderFinal FormId(string formId)
+            {
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.FormId = formId;
+                return new OptionObject2FormObjectBuilderFinal(optionObject, formObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a <see cref="FormObject"/> build.
+        /// </summary>
+        public class OptionObject2FormObjectBuilderFinal
+        {
+            protected readonly OptionObject2 optionObject;
+            protected readonly FormObject formObject;
+            /// <summary>
+            /// Constructs a OptionObject2FormObjectBuilderFinal used to add a FormObject to a OptionObject2
+            /// </summary>
+            /// <param name="optionObject">The <see cref="OptionObject2"/> to add <see cref="FormObject"/>.</param>
+            /// <param name="formObject">The <see cref="FormObject"/> to complete.</param>
+            public OptionObject2FormObjectBuilderFinal(OptionObject2 optionObject, FormObject formObject)
+            {
+                this.optionObject = optionObject;
+                this.formObject = formObject;
+            }
+            /// <summary>
+            /// Sets the CurrentRow of the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to set as the CurrentRow.</param>
+            /// <returns>A <see cref=" OptionObject2FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public OptionObject2FormObjectBuilderFinal CurrentRow(RowObject rowObject)
+            {
+                formObject.CurrentRow = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                return this;
+            }
+            /// <summary>
+            /// Indicate the <see cref="FormObject"/> uses a Multiple-Iteration Table.
+            /// <para>Must be set to enable the adding of OtherRows to the <see cref="FormObject"/></para>
+            /// </summary>
+            /// <returns>A <see cref="OptionObject2FormObjectBuilderMIFinal"/></returns>
+            public OptionObject2FormObjectBuilderMIFinal MultipleIteration()
+            {
+                formObject.MultipleIteration = true;
+                return new OptionObject2FormObjectBuilderMIFinal(optionObject, formObject);
+            }
+            /// <summary>
+            /// Adds FormObject to the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <returns>A <see cref="OptionObject2BuilderFinal"/></returns>
+            public OptionObject2.OptionObject2BuilderFinal AddForm()
+            {
+                optionObject.AddFormObject(formObject);
+                return new OptionObject2.OptionObject2BuilderFinal(optionObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a multiple iteration <see cref="FormObject"/> build.
+        /// </summary>
+        public class OptionObject2FormObjectBuilderMIFinal : OptionObject2FormObjectBuilderFinal
+        {
+            public OptionObject2FormObjectBuilderMIFinal(OptionObject2 optionObject, FormObject formObject) : base(optionObject, formObject) { }
+            /// <summary>
+            /// Adds another RowObject to the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to add.</param>
+            /// <returns>A <see cref="OptionObject2FormObjectBuilderMIFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public OptionObject2FormObjectBuilderMIFinal OtherRow(RowObject rowObject)
+            {
+                if (rowObject == null)
+                    throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.OtherRows.Add(rowObject);
+                return this;
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for adding FormObjects to OptionObject2015s
+        /// </summary>
+        public class OptionObject2015FormObjectBuilder
+        {
+            protected readonly OptionObject2015 optionObject;
+            protected readonly FormObject formObject;
+            /// <summary>
+            /// Constructs a OptionObjectFormObjectBuilder
+            /// </summary>
+            /// <param name="optionObject"></param>
+            public OptionObject2015FormObjectBuilder(OptionObject2015 optionObject)
+            {
+                this.optionObject = optionObject;
+                formObject = new FormObject();
+            }
+            /// <summary>
+            /// Sets the FormId of the <see cref="FormObject"/>.
+            /// This is required before any other attributes may be set on the <see cref="FormObject"/> built.
+            /// </summary>
+            /// <param name="formId">Required. The FormId to assign to the <see cref="FormObject"/></param>
+            /// <returns>A <see cref="OptionObject2015FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015FormObjectBuilderFinal FormId(string formId)
+            {
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.FormId = formId;
+                return new OptionObject2015FormObjectBuilderFinal(optionObject, formObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a <see cref="FormObject"/> build.
+        /// </summary>
+        public class OptionObject2015FormObjectBuilderFinal
+        {
+            protected readonly OptionObject2015 optionObject;
+            protected readonly FormObject formObject;
+            /// <summary>
+            /// Constructs a OptionObject2015FormObjectBuilderFinal used to add a FormObject to a OptionObject2015
+            /// </summary>
+            /// <param name="optionObject">The <see cref="OptionObject2015"/> to add <see cref="FormObject"/>.</param>
+            /// <param name="formObject">The <see cref="FormObject"/> to complete.</param>
+            public OptionObject2015FormObjectBuilderFinal(OptionObject2015 optionObject, FormObject formObject)
+            {
+                this.optionObject = optionObject;
+                this.formObject = formObject;
+            }
+            /// <summary>
+            /// Sets the CurrentRow of the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to set as the CurrentRow.</param>
+            /// <returns>A <see cref=" OptionObject2015FormObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public OptionObject2015FormObjectBuilderFinal CurrentRow(RowObject rowObject)
+            {
+                formObject.CurrentRow = rowObject ?? throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                return this;
+            }
+            /// <summary>
+            /// Indicate the <see cref="FormObject"/> uses a Multiple-Iteration Table.
+            /// <para>Must be set to enable the adding of OtherRows to the <see cref="FormObject"/></para>
+            /// </summary>
+            /// <returns>A <see cref="OptionObject2015FormObjectBuilderMIFinal"/></returns>
+            public OptionObject2015FormObjectBuilderMIFinal MultipleIteration()
+            {
+                formObject.MultipleIteration = true;
+                return new OptionObject2015FormObjectBuilderMIFinal(optionObject, formObject);
+            }
+            /// <summary>
+            /// Adds FormObject to the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <returns>A <see cref="OptionObject2015BuilderFinal"/></returns>
             public OptionObject2015.OptionObject2015BuilderFinal AddForm()
             {
                 optionObject.AddFormObject(formObject);
                 return new OptionObject2015.OptionObject2015BuilderFinal(optionObject);
+            }
+        }
+        /// <summary>
+        /// A Faceted Fluent Builder for the completion of a multiple iteration <see cref="FormObject"/> build.
+        /// </summary>
+        public class OptionObject2015FormObjectBuilderMIFinal : OptionObject2015FormObjectBuilderFinal
+        {
+            public OptionObject2015FormObjectBuilderMIFinal(OptionObject2015 optionObject, FormObject formObject) : base(optionObject, formObject) { }
+            /// <summary>
+            /// Adds another RowObject to the <see cref="FormObject"/>.
+            /// </summary>
+            /// <param name="rowObject">The <see cref="RowObject"/> to add.</param>
+            /// <returns>A <see cref="OptionObject2015FormObjectBuilderMIFinal"/></returns>
+            /// <exception cref="ArgumentNullException">Thrown if no <see cref="RowObject"/> provided.</exception>
+            public OptionObject2015FormObjectBuilderMIFinal OtherRow(RowObject rowObject)
+            {
+                if (rowObject == null)
+                    throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                formObject.OtherRows.Add(rowObject);
+                return this;
             }
         }
     }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject.cs
@@ -1,7 +1,9 @@
 ﻿using Newtonsoft.Json;
 using RarelySimple.AvatarScriptLink.Helpers;
 using RarelySimple.AvatarScriptLink.Objects.Advanced;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Xml.Serialization;
 
 namespace RarelySimple.AvatarScriptLink.Objects
@@ -53,6 +55,34 @@ namespace RarelySimple.AvatarScriptLink.Objects
             , facility, entityId, episodeNumber
             , systemCode, "", "", "", "", forms)
         { }
+        /// <summary>
+        /// Initializes a <see cref="OptionObject"/>
+        /// </summary>
+        /// <returns>An <see cref="OptionObject"/></returns>
+        public static OptionObject Initialize() { return new OptionObject(); }
+        /// <summary>
+        /// Initializes an <see cref="OptionObjectBuilder"/> to help construct an <see cref="OptionObject"/>
+        /// <code>
+        /// // Sample usage
+        /// OptionObject optionObject = OptionObject.Builder()
+        ///                                         .OptionId("123")
+        ///                                         .OptionUserId("FLAST")
+        ///                                         .OptionStaffId("4567")
+        ///                                         .Facility("1")
+        ///                                         .EntityId("23")
+        ///                                         .EpisodeNumber(1)
+        ///                                         .SystemCode("SBOX")
+        ///                                         .Form("1")
+        ///                                             .CurrentRow()
+        ///                                         .Form("2")
+        ///                                             .CurrentRow()
+        ///                                             .MultipleIteration()
+        ///                                             .OtherRow()
+        ///                                         .Build();
+        /// </code>
+        /// </summary>
+        /// <returns></returns>
+        public static OptionObjectBuilder Builder() { return new OptionObjectBuilder(); }
 
 
         [JsonIgnore]
@@ -153,5 +183,148 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         /// <returns><see cref="string"/> of all of the contents of the <see cref="OptionObject"/> formatted as XML.</returns>
         public override string ToXml() => OptionObjectHelpers.TransformToXml(this);
+
+        public class OptionObjectBuilder
+        {
+            protected readonly OptionObject optionObject;
+            /// <summary>
+            /// Constructs a OptionObjectBuilder
+            /// </summary>
+            public OptionObjectBuilder()
+            {
+                optionObject = new OptionObject();
+            }
+            /// <summary>
+            /// Sets the OptionId of the <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="optionId"></param>
+            /// <returns>An <see cref="OptionObjectBuilder"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal OptionId(string optionId)
+            {
+                if (string.IsNullOrEmpty(optionId))
+                    throw new ArgumentNullException(nameof(optionId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionId = optionId;
+                return new OptionObjectBuilderFinal(optionObject);
+            }
+        }
+        public class OptionObjectBuilderFinal
+        {
+            protected readonly OptionObject optionObject;
+            /// <summary>
+            /// Constructs a OptionObjectBuilder
+            /// </summary>
+            public OptionObjectBuilderFinal(OptionObject optionObject)
+            {
+                this.optionObject = optionObject ?? throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Sets the EntityId of the <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="entityId"></param>
+            /// <returns>An <see cref="OptionObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal EntityId(string entityId)
+            {
+                if (string.IsNullOrEmpty(entityId))
+                    throw new ArgumentNullException(nameof(entityId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.EntityID = entityId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the EpisodeNumber of the <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="episodeNumber"></param>
+            /// <returns>An <see cref="OptionObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal EpisodeNumber(double episodeNumber)
+            {
+                optionObject.EpisodeNumber = episodeNumber;
+                return this;
+            }
+            /// <summary>
+            /// Sets the Facility of the <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="facility"></param>
+            /// <returns>An <see cref="OptionObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal Facility(string facility)
+            {
+                if (string.IsNullOrEmpty(facility))
+                    throw new ArgumentNullException(nameof(facility), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.Facility = facility;
+                return this;
+            }
+            /// <summary>
+            /// Sets the OptionStaffId of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="optionStaffId"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal OptionStaffId(string optionStaffId)
+            {
+                if (string.IsNullOrEmpty(optionStaffId))
+                    throw new ArgumentNullException(nameof(optionStaffId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionStaffId = optionStaffId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the OptionUserId of the <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="optionUserId"></param>
+            /// <returns>An <see cref="OptionObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal OptionUserId(string optionUserId)
+            {
+                if (string.IsNullOrEmpty(optionUserId))
+                    throw new ArgumentNullException(nameof(optionUserId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionUserId = optionUserId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the SystemCode of the <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="systemCode"></param>
+            /// <returns>An <see cref="OptionObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal SystemCode(string systemCode)
+            {
+                if (string.IsNullOrEmpty(systemCode))
+                    throw new ArgumentNullException(nameof(systemCode), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.SystemCode = systemCode;
+                return this;
+            }
+            /// <summary>
+            /// Initializes a builder to construct a FormObject within the OptionObject builder.
+            /// </summary>
+            /// <returns>A <see cref="OptionObjectFormObjectBuilder"/> to start<see cref="FormObject"/> build.</returns>
+            public FormObject.OptionObjectFormObjectBuilder Form()
+            {
+                return new FormObject.OptionObjectFormObjectBuilder(optionObject);
+            }
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="formObject"></param>
+            /// <returns>An <see cref="OptionObjectBuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObjectBuilderFinal Form(FormObject formObject)
+            {
+                if (optionObject.Forms == null)
+                {
+                    optionObject.Forms = new List<FormObject>();
+                }
+                optionObject.Forms.Add(formObject);
+                return this;
+            }
+            /// <summary>
+            /// Builds the <see cref="OptionObject"/> based on the supplied build parameters.
+            /// </summary>
+            /// <returns>A <see cref="OptionObject"/></returns>
+            public OptionObject Build()
+            {
+                return optionObject;
+            }
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2.cs
@@ -3,6 +3,7 @@ using RarelySimple.AvatarScriptLink.Helpers;
 using RarelySimple.AvatarScriptLink.Objects.Advanced;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Xml.Serialization;
 
 namespace RarelySimple.AvatarScriptLink.Objects
@@ -62,6 +63,37 @@ namespace RarelySimple.AvatarScriptLink.Objects
             , systemCode, namespaceName, parentNamespace, serverName
             , "", forms)
         { }
+        /// <summary>
+        /// Initializes a <see cref="OptionObject2"/>
+        /// </summary>
+        /// <returns>An <see cref="OptionObject2"/></returns>
+        public static OptionObject2 Initialize() { return new OptionObject2(); }
+        /// <summary>
+        /// Initializes an <see cref="OptionObject2Builder"/> to help construct an <see cref="OptionObject2"/>
+        /// <code>
+        /// // Sample usage
+        /// OptionObject2 optionObject = OptionObject2.Builder()
+        ///                                           .OptionId("123")
+        ///                                           .OptionUserId("FLAST")
+        ///                                           .OptionStaffId("4567")
+        ///                                           .Facility("1")
+        ///                                           .EntityId("23")
+        ///                                           .EpisodeNumber(1)
+        ///                                           .SystemCode("SBOX")
+        ///                                           .NamespaceName("XXX")
+        ///                                           .ParentNamespace("YYY")
+        ///                                           .ServerName("avatar.domain.local")
+        ///                                           .Form("1")
+        ///                                               .CurrentRow()
+        ///                                           .Form("2")
+        ///                                               .CurrentRow()
+        ///                                               .MultipleIteration()
+        ///                                               .OtherRow()
+        ///                                           .Build();
+        /// </code>
+        /// </summary>
+        /// <returns></returns>
+        public static OptionObject2Builder Builder() { return new OptionObject2Builder(); }
 
 
         [JsonIgnore]
@@ -138,5 +170,200 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         /// <returns><see cref="string"/> of all of the contents of the <see cref="OptionObject"/> formatted as XML.</returns>
         public override string ToXml() => OptionObjectHelpers.TransformToXml(this);
+
+        public class OptionObject2Builder
+        {
+            protected readonly OptionObject2 optionObject;
+            /// <summary>
+            /// Constructs a OptionObject2Builder
+            /// </summary>
+            public OptionObject2Builder()
+            {
+                optionObject = new OptionObject2();
+            }
+            /// <summary>
+            /// Sets the OptionId of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="optionId"></param>
+            /// <returns>An <see cref="OptionObject2Builder"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal OptionId(string optionId)
+            {
+                if (string.IsNullOrEmpty(optionId))
+                    throw new ArgumentNullException(nameof(optionId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionId = optionId;
+                return new OptionObject2BuilderFinal(optionObject);
+            }
+        }
+        public class OptionObject2BuilderFinal
+        {
+            protected readonly OptionObject2 optionObject;
+            /// <summary>
+            /// Constructs a OptionObject2Builder
+            /// </summary>
+            public OptionObject2BuilderFinal(OptionObject2 optionObject)
+            {
+                this.optionObject = optionObject ?? throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Sets the EntityId of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="entityId"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal EntityId(string entityId)
+            {
+                if (string.IsNullOrEmpty(entityId))
+                    throw new ArgumentNullException(nameof(entityId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.EntityID = entityId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the EpisodeNumber of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="episodeNumber"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal EpisodeNumber(double episodeNumber)
+            {
+                optionObject.EpisodeNumber = episodeNumber;
+                return this;
+            }
+            /// <summary>
+            /// Sets the Facility of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="facility"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal Facility(string facility)
+            {
+                if (string.IsNullOrEmpty(facility))
+                    throw new ArgumentNullException(nameof(facility), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.Facility = facility;
+                return this;
+            }
+            /// <summary>
+            /// Sets the NamespaceName of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="namespaceName"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal NamespaceName(string namespaceName)
+            {
+                if (string.IsNullOrEmpty(namespaceName))
+                    throw new ArgumentNullException(nameof(namespaceName), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.NamespaceName = namespaceName;
+                return this;
+            }
+            /// <summary>
+            /// Sets the OptionStaffId of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="optionStaffId"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal OptionStaffId(string optionStaffId)
+            {
+                if (string.IsNullOrEmpty(optionStaffId))
+                    throw new ArgumentNullException(nameof(optionStaffId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionStaffId = optionStaffId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the OptionUserId of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="optionUserId"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal OptionUserId(string optionUserId)
+            {
+                if (string.IsNullOrEmpty(optionUserId))
+                    throw new ArgumentNullException(nameof(optionUserId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionUserId = optionUserId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the ParentNamespace of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="parentNamespace"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal ParentNamespace(string parentNamespace)
+            {
+                if (string.IsNullOrEmpty(parentNamespace))
+                    throw new ArgumentNullException(nameof(parentNamespace), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.ParentNamespace = parentNamespace;
+                return this;
+            }
+            /// <summary>
+            /// Sets the ServerName of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="serverName"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal ServerName(string serverName)
+            {
+                if (string.IsNullOrEmpty(serverName))
+                    throw new ArgumentNullException(nameof(serverName), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.ServerName = serverName;
+                return this;
+            }
+            /// <summary>
+            /// Sets the SessionToken of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="sessionToken"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal SessionToken(string sessionToken)
+            {
+                if (string.IsNullOrEmpty(sessionToken))
+                    throw new ArgumentNullException(nameof(sessionToken), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.SessionToken = sessionToken;
+                return this;
+            }
+            /// <summary>
+            /// Sets the SystemCode of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="systemCode"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal SystemCode(string systemCode)
+            {
+                if (string.IsNullOrEmpty(systemCode))
+                    throw new ArgumentNullException(nameof(systemCode), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.SystemCode = systemCode;
+                return this;
+            }
+            /// <summary>
+            /// Initializes a builder to construct a FormObject within the OptionObject2 builder.
+            /// </summary>
+            /// <returns>A <see cref="OptionObject2FormObjectBuilder"/> to start<see cref="FormObject"/> build.</returns>
+            public FormObject.OptionObject2FormObjectBuilder Form()
+            {
+                return new FormObject.OptionObject2FormObjectBuilder(optionObject);
+            }
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> of the <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="formObject"></param>
+            /// <returns>An <see cref="OptionObject2BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2BuilderFinal Form(FormObject formObject)
+            {
+                if (optionObject.Forms == null)
+                {
+                    optionObject.Forms = new List<FormObject>();
+                }
+                optionObject.Forms.Add(formObject);
+                return this;
+            }
+            /// <summary>
+            /// Builds the <see cref="OptionObject2"/> based on the supplied build parameters.
+            /// </summary>
+            /// <returns>A <see cref="OptionObject2"/></returns>
+            public OptionObject2 Build()
+            {
+                return optionObject;
+            }
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2015.cs
@@ -327,10 +327,10 @@ namespace RarelySimple.AvatarScriptLink.Objects
             /// <summary>
             /// Initializes a builder to construct a FormObject within the OptionObject2015 builder.
             /// </summary>
-            /// <returns>A <see cref="OptionObjectFormObjectBuilder"/> to start<see cref="FormObject"/> build.</returns>
-            public FormObject.OptionObjectFormObjectBuilder Form()
+            /// <returns>A <see cref="OptionObject2015FormObjectBuilder"/> to start<see cref="FormObject"/> build.</returns>
+            public FormObject.OptionObject2015FormObjectBuilder Form()
             {
-                return new FormObject.OptionObjectFormObjectBuilder(optionObject);
+                return new FormObject.OptionObject2015FormObjectBuilder(optionObject);
             }
             /// <summary>
             /// Adds a <see cref="FormObject"/> of the <see cref="OptionObject2015"/>.

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2015.cs
@@ -1,6 +1,8 @@
 ﻿using RarelySimple.AvatarScriptLink.Helpers;
 using RarelySimple.AvatarScriptLink.Objects.Advanced;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace RarelySimple.AvatarScriptLink.Objects
 {
@@ -62,7 +64,38 @@ namespace RarelySimple.AvatarScriptLink.Objects
             , systemCode, namespaceName, parentNamespace, serverName
             , sessionToken, forms)
         { }
-
+        /// <summary>
+        /// Initializes a <see cref="OptionObject2015"/>
+        /// </summary>
+        /// <returns>An <see cref="OptionObject2015"/></returns>
+        public static OptionObject2015 Initialize() { return new OptionObject2015(); }
+        /// <summary>
+        /// Initializes an <see cref="OptionObject2015Builder"/> to help construct an <see cref="OptionObject2015"/>
+        /// <code>
+        /// // Sample usage
+        /// OptionObject2015 optionObject = OptionObject2015.Builder()
+        ///                                                 .OptionId("123")
+        ///                                                 .OptionUserId("FLAST")
+        ///                                                 .OptionStaffId("4567")
+        ///                                                 .Facility("1")
+        ///                                                 .EntityId("23")
+        ///                                                 .EpisodeNumber(1)
+        ///                                                 .SystemCode("SBOX")
+        ///                                                 .NamespaceName("XXX")
+        ///                                                 .ParentNamespace("YYY")
+        ///                                                 .ServerName("avatar.domain.local")
+        ///                                                 .SessionToken("asdfghjkl")
+        ///                                                 .Form("1")
+        ///                                                     .CurrentRow()
+        ///                                                 .Form("2")
+        ///                                                     .CurrentRow()
+        ///                                                     .MultipleIteration()
+        ///                                                     .OtherRow()
+        ///                                                 .Build();
+        /// </code>
+        /// </summary>
+        /// <returns></returns>
+        public static OptionObject2015Builder Builder() { return new OptionObject2015Builder(); }
         /// <summary>
         /// Clones the <see cref="OptionObject2015"/>.
         /// </summary>
@@ -128,5 +161,200 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// </summary>
         /// <returns><see cref="string"/> of all of the contents of the <see cref="OptionObject2015"/> formatted as XML.</returns>
         public override string ToXml() => OptionObjectHelpers.TransformToXml(this);
+
+        public class OptionObject2015Builder
+        {
+            protected readonly OptionObject2015 optionObject;
+            /// <summary>
+            /// Constructs a OptionObject2015Builder
+            /// </summary>
+            public OptionObject2015Builder()
+            {
+                optionObject = new OptionObject2015();
+            }
+            /// <summary>
+            /// Sets the OptionId of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="optionId"></param>
+            /// <returns>An <see cref="OptionObject2015Builder"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal OptionId(string optionId)
+            {
+                if (string.IsNullOrEmpty(optionId))
+                    throw new ArgumentNullException(nameof(optionId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionId = optionId;
+                return new OptionObject2015BuilderFinal(optionObject);
+            }
+        }
+        public class OptionObject2015BuilderFinal
+        {
+            protected readonly OptionObject2015 optionObject;
+            /// <summary>
+            /// Constructs a OptionObject2015Builder
+            /// </summary>
+            public OptionObject2015BuilderFinal(OptionObject2015 optionObject)
+            {
+                this.optionObject = optionObject ?? throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+            }
+            /// <summary>
+            /// Sets the EntityId of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="entityId"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal EntityId(string entityId)
+            {
+                if (string.IsNullOrEmpty(entityId))
+                    throw new ArgumentNullException(nameof(entityId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.EntityID = entityId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the EpisodeNumber of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="episodeNumber"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal EpisodeNumber(double episodeNumber)
+            {
+                optionObject.EpisodeNumber = episodeNumber;
+                return this;
+            }
+            /// <summary>
+            /// Sets the Facility of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="facility"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal Facility(string facility)
+            {
+                if (string.IsNullOrEmpty(facility))
+                    throw new ArgumentNullException(nameof(facility), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.Facility = facility;
+                return this;
+            }
+            /// <summary>
+            /// Sets the NamespaceName of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="namespaceName"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal NamespaceName(string namespaceName)
+            {
+                if (string.IsNullOrEmpty(namespaceName))
+                    throw new ArgumentNullException(nameof(namespaceName), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.NamespaceName = namespaceName;
+                return this;
+            }
+            /// <summary>
+            /// Sets the OptionStaffId of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="optionStaffId"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal OptionStaffId(string optionStaffId)
+            {
+                if (string.IsNullOrEmpty(optionStaffId))
+                    throw new ArgumentNullException(nameof(optionStaffId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionStaffId = optionStaffId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the OptionUserId of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="optionUserId"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal OptionUserId(string optionUserId)
+            {
+                if (string.IsNullOrEmpty(optionUserId))
+                    throw new ArgumentNullException(nameof(optionUserId), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.OptionUserId = optionUserId;
+                return this;
+            }
+            /// <summary>
+            /// Sets the ParentNamespace of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="parentNamespace"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal ParentNamespace(string parentNamespace)
+            {
+                if (string.IsNullOrEmpty(parentNamespace))
+                    throw new ArgumentNullException(nameof(parentNamespace), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.ParentNamespace = parentNamespace;
+                return this;
+            }
+            /// <summary>
+            /// Sets the ServerName of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="serverName"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal ServerName(string serverName)
+            {
+                if (string.IsNullOrEmpty(serverName))
+                    throw new ArgumentNullException(nameof(serverName), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.ServerName = serverName;
+                return this;
+            }
+            /// <summary>
+            /// Sets the SessionToken of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="sessionToken"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal SessionToken(string sessionToken)
+            {
+                if (string.IsNullOrEmpty(sessionToken))
+                    throw new ArgumentNullException(nameof(sessionToken), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.SessionToken = sessionToken;
+                return this;
+            }
+            /// <summary>
+            /// Sets the SystemCode of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="systemCode"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal SystemCode(string systemCode)
+            {
+                if (string.IsNullOrEmpty(systemCode))
+                    throw new ArgumentNullException(nameof(systemCode), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
+                optionObject.SystemCode = systemCode;
+                return this;
+            }
+            /// <summary>
+            /// Initializes a builder to construct a FormObject within the OptionObject2015 builder.
+            /// </summary>
+            /// <returns>A <see cref="OptionObjectFormObjectBuilder"/> to start<see cref="FormObject"/> build.</returns>
+            public FormObject.OptionObjectFormObjectBuilder Form()
+            {
+                return new FormObject.OptionObjectFormObjectBuilder(optionObject);
+            }
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> of the <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="formObject"></param>
+            /// <returns>An <see cref="OptionObject2015BuilderFinal"/></returns>
+            /// <exception cref="ArgumentNullException"></exception>
+            public OptionObject2015BuilderFinal Form(FormObject formObject)
+            {
+                if (optionObject.Forms == null)
+                {
+                    optionObject.Forms = new List<FormObject>();
+                }
+                optionObject.Forms.Add(formObject);
+                return this;
+            }
+            /// <summary>
+            /// Builds the <see cref="OptionObject2015"/> based on the supplied build parameters.
+            /// </summary>
+            /// <returns>A <see cref="OptionObject2015"/></returns>
+            public OptionObject2015 Build()
+            {
+                return optionObject;
+            }
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/RarelySimple.AvatarScriptLink.csproj
+++ b/dotnet/RarelySimple.AvatarScriptLink/RarelySimple.AvatarScriptLink.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Scott Olson Jr</Authors>
     <Company>Rarely Simple</Company>
@@ -9,7 +9,7 @@
     <RepositoryUrl>https://github.com/rarelysimple/RarelySimple.AvatarScriptLink</RepositoryUrl>
     <PackageProjectUrl>https://scriptlink.rarelysimple.com/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <Copyright>Copyright © 2022 Scott Olson Jr</Copyright>
+    <Copyright>Copyright © 2023 Scott Olson Jr</Copyright>
     <Description>AvatarScriptLink.NET is a library for accelerating Netsmart myAvatar ScriptLink API development.</Description>
     <NeutralLanguage>en-US</NeutralLanguage>
     <SignAssembly>true</SignAssembly>
@@ -18,7 +18,7 @@
     <PackageId>RarelySimple.AvatarScriptLink</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
-    <Version>1.1.10</Version>
+    <Version>1.2.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
This update adds the Fluent Builder capability to the various OptionObject classes which can be helpful when writing unit tests.
```cs
OptionObject2015 optionObject = OptionObject2015.Builder()
                                                .OptionId("OPT1234")
                                                .Form(formObject)
                                                .Form(miFormObject)
                                                .Build();
```