### PR TITLE
Remove Overwriting of Error Code and Message

### DIFF
--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/GetReturnOptionObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/GetReturnOptionObjectTests.cs
@@ -14,15 +14,16 @@ namespace RarelySimple.AvatarScriptLink.Tests.HelpersTests
         [TestInitialize]
         public void TestInitialize()
         {
-            this.optionObject = new OptionObject();
-
-            optionObject.EntityID = "123456";
-            optionObject.EpisodeNumber = 1;
-            optionObject.Facility = "1";
-            optionObject.OptionId = "USER00";
-            optionObject.OptionStaffId = "1234";
-            optionObject.OptionUserId = "username";
-            optionObject.SystemCode = "UAT";
+            optionObject = new OptionObject
+            {
+                EntityID = "123456",
+                EpisodeNumber = 1,
+                Facility = "1",
+                OptionId = "USER00",
+                OptionStaffId = "1234",
+                OptionUserId = "username",
+                SystemCode = "UAT"
+            };
         }
 
         [TestMethod]
@@ -88,6 +89,28 @@ namespace RarelySimple.AvatarScriptLink.Tests.HelpersTests
             string expected = "Hello World!";
             OptionObject returnOptionObject = (OptionObject)OptionObjectHelpers.GetReturnOptionObject((IOptionObject)optionObject, 1, expected);
             Assert.AreEqual(expected, returnOptionObject.ErrorMesg);
+        }
+
+        [TestMethod]
+        [TestCategory("ScriptLinkHelpers")]
+        public void GetReturnOptionObject_ErrorMessage_PresetPreserved()
+        {
+            string expected = "Hello World!";
+            OptionObject presetOptionObject = OptionObject.Initialize();
+            presetOptionObject.ErrorMesg = expected;
+            OptionObject returnOptionObject = (OptionObject)OptionObjectHelpers.GetReturnOptionObject(presetOptionObject);
+            Assert.AreEqual(expected, returnOptionObject.ErrorMesg);
+        }
+
+        [TestMethod]
+        [TestCategory("ScriptLinkHelpers")]
+        public void GetReturnOptionObject_ErrorCode_PresetPreserved()
+        {
+            double expected = 3;
+            OptionObject presetOptionObject = OptionObject.Initialize();
+            presetOptionObject.ErrorCode = expected;
+            OptionObject returnOptionObject = (OptionObject)OptionObjectHelpers.GetReturnOptionObject(presetOptionObject);
+            Assert.AreEqual(expected, returnOptionObject.ErrorCode);
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2015Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2015Tests.cs
@@ -578,5 +578,29 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             Assert.IsTrue(optionObject.IsFieldPresent("123"));
             Assert.IsFalse(returnOptionObject.IsFieldPresent("123"));
         }
+
+        [TestMethod]
+        [TestCategory("OptionObject2015")]
+        public void OptionObject2015_ReturnOptionObject_ErrorCodeNotOverwritten()
+        {
+            double expected = 3;
+            OptionObject2015 optionObject = OptionObject2015.Builder().OptionId("USER123").Build();
+            optionObject.ErrorCode = expected;
+            OptionObject2015 returnOptionObject = optionObject.ToReturnOptionObject();
+
+            Assert.AreEqual(expected, returnOptionObject.ErrorCode);
+        }
+
+        [TestMethod]
+        [TestCategory("OptionObject2015")]
+        public void OptionObject2015_ReturnOptionObject_ErrorMesgNotOverwritten()
+        {
+            string expected = "Preset error message";
+            OptionObject2015 optionObject = OptionObject2015.Builder().OptionId("USER123").Build();
+            optionObject.ErrorMesg = expected;
+            OptionObject2015 returnOptionObject = optionObject.ToReturnOptionObject();
+
+            Assert.AreEqual(expected, returnOptionObject.ErrorMesg);
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObject2Tests.cs
@@ -572,5 +572,29 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             Assert.IsTrue(optionObject.IsFieldPresent("123"));
             Assert.IsFalse(returnOptionObject.IsFieldPresent("123"));
         }
+
+        [TestMethod]
+        [TestCategory("OptionObject2")]
+        public void OptionObject2_ReturnOptionObject_ErrorCodeNotOverwritten()
+        {
+            double expected = 3;
+            OptionObject2 optionObject = OptionObject2.Builder().OptionId("USER123").Build();
+            optionObject.ErrorCode = expected;
+            OptionObject2 returnOptionObject = optionObject.ToReturnOptionObject();
+
+            Assert.AreEqual(expected, returnOptionObject.ErrorCode);
+        }
+
+        [TestMethod]
+        [TestCategory("OptionObject2")]
+        public void OptionObject2_ReturnOptionObject_ErrorMesgNotOverwritten()
+        {
+            string expected = "Preset error message";
+            OptionObject2 optionObject = OptionObject2.Builder().OptionId("USER123").Build();
+            optionObject.ErrorMesg = expected;
+            OptionObject2 returnOptionObject = optionObject.ToReturnOptionObject();
+
+            Assert.AreEqual(expected, returnOptionObject.ErrorMesg);
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Objects/OptionObjectTests.cs
@@ -542,5 +542,29 @@ namespace RarelySimple.AvatarScriptLink.Tests.ObjectsTests
             Assert.IsTrue(optionObject.IsFieldPresent("123"));
             Assert.IsFalse(returnOptionObject.IsFieldPresent("123"));
         }
+
+        [TestMethod]
+        [TestCategory("OptionObject")]
+        public void OptionObject_ReturnOptionObject_ErrorCodeNotOverwritten()
+        {
+            double expected = 3;
+            OptionObject optionObject = OptionObject.Builder().OptionId("USER123").Build();
+            optionObject.ErrorCode = expected;
+            OptionObject returnOptionObject = optionObject.ToReturnOptionObject();
+
+            Assert.AreEqual(expected, returnOptionObject.ErrorCode);
+        }
+
+        [TestMethod]
+        [TestCategory("OptionObject")]
+        public void OptionObject_ReturnOptionObject_ErrorMesgNotOverwritten()
+        {
+            string expected = "Preset error message";
+            OptionObject optionObject = OptionObject.Builder().OptionId("USER123").Build();
+            optionObject.ErrorMesg = expected;
+            OptionObject returnOptionObject = optionObject.ToReturnOptionObject();
+
+            Assert.AreEqual(expected, returnOptionObject.ErrorMesg);
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetReturnOptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetReturnOptionObject.cs
@@ -14,7 +14,9 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         {
             if (optionObject == null)
                 throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-            return GetReturnOptionObject(optionObject, 0, "");
+            IOptionObject returnOptionObject = ((OptionObjectBase)optionObject).Clone();
+            RemoveUneditedRows(returnOptionObject);
+            return returnOptionObject;
         }
         /// <summary>
         /// Used to create the <see cref="IOptionObject"/> for return to myAvatar using provide Error Code and Error Message.
@@ -40,7 +42,9 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         {
             if (optionObject == null)
                 throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-            return GetReturnOptionObject(optionObject, 0, "");
+            IOptionObject2 returnOptionObject = ((OptionObjectBase)optionObject).Clone();
+            RemoveUneditedRows(returnOptionObject);
+            return returnOptionObject;
         }
         /// <summary>
         /// Used to create the <see cref="IOptionObject2"/> for return to myAvatar using provide Error Code and Error Message.
@@ -67,10 +71,12 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         {
             if (optionObject == null)
                 throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString("parameterCannotBeNull", CultureInfo.CurrentCulture));
-            return GetReturnOptionObject(optionObject, 0, "");
+            IOptionObject2015 returnOptionObject = ((OptionObjectBase)optionObject).Clone();
+            RemoveUneditedRows(returnOptionObject);
+            return returnOptionObject;
         }
         /// <summary>
-        /// Used to create the <see cref="IOptionObject2015"/> for return to myAvatar using provide Error Code and Error Message.
+        /// Used to create the <see cref="IOptionObject2015"/> for return to myAvatar using provided Error Code and Error Message.
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="errorCode"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2.cs
@@ -137,7 +137,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// Transforms the <see cref="OptionObject2"/>  to an <see cref="OptionObject"/>.
         /// </summary>
         /// <returns></returns>
-        public override OptionObject ToOptionObject() => (OptionObject)OptionObjectHelpers.TransformToOptionObject((IOptionObject2)this);
+        public override OptionObject ToOptionObject() => OptionObjectHelpers.TransformToOptionObject((IOptionObject2)this);
 
         /// <summary>
         /// Transforms the <see cref="OptionObject2"/>  to an <see cref="OptionObject2"/>.
@@ -149,7 +149,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// Transforms the <see cref="OptionObject2"/>  to an <see cref="OptionObject2015"/>.
         /// </summary>
         /// <returns></returns>
-        public override OptionObject2015 ToOptionObject2015() => (OptionObject2015)OptionObjectHelpers.TransformToOptionObject2015((IOptionObject2)this);
+        public override OptionObject2015 ToOptionObject2015() => (OptionObject2015)OptionObjectHelpers.TransformToOptionObject2015(this);
 
         /// <summary>
         /// Creates an <see cref="OptionObject2"/> with the minimal information required to return.

--- a/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Objects/OptionObject2015.cs
@@ -154,7 +154,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         /// <param name="errorCode"></param>
         /// <param name="errorMessage"></param>
         /// <returns></returns>
-        public new OptionObject2015 ToReturnOptionObject(double errorCode, string errorMessage) => (OptionObject2015)OptionObjectHelpers.GetReturnOptionObject((IOptionObject2015)this, errorCode, errorMessage);
+        public new OptionObject2015 ToReturnOptionObject(double errorCode, string errorMessage) => (OptionObject2015)OptionObjectHelpers.GetReturnOptionObject(this, errorCode, errorMessage);
 
         /// <summary>
         /// Returns a <see cref="string"/> with all of the contents of the <see cref="OptionObject2015"/> formatted as XML.


### PR DESCRIPTION
When calling ToReturnOptionObject() the ErrorCode and ErrorMesg will not be overwritten to defaults but preserve any values previously set.