### PR TITLE
Implement AddFormObject Method

### DIFF
--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/FormObjectDecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/FormObjectDecoratorTests.cs
@@ -33,6 +33,91 @@ public class FormObjectDecoratorTests
         Assert.IsNull(actual.CurrentRow);
     }
 
+    #region Builder
+
+    [TestMethod]
+    public void TestFormObjectDecorator_Builder_Expected()
+    {
+        var fieldNumber = "123.45";
+        var expected = "initial value";
+        var fieldObject = new FieldObject()
+        {
+            Enabled = "1",
+            FieldNumber = fieldNumber,
+            FieldValue = expected,
+            Lock = "1",
+            Required = "1"
+        };
+        var rowObject = new RowObject()
+        {
+            Fields = [fieldObject],
+            RowId = "456||1"
+        };
+        var formObject = new FormObject()
+        {
+            CurrentRow = rowObject,
+            FormId = "456"
+        };
+        var decorator = FormObjectDecorator.Builder(formObject).Build();
+        Assert.AreEqual(expected, decorator.GetFieldValue(fieldNumber));
+        Assert.IsTrue(decorator.IsFieldEnabled(fieldNumber));
+        Assert.IsTrue(decorator.IsFieldLocked(fieldNumber));
+        Assert.IsTrue(decorator.IsFieldRequired(fieldNumber));        
+    }
+
+    [TestMethod]
+    public void TestFormObjectDecorator_Builder_CurrentRowExpected()
+    {
+        var expected = "456||1";
+        var rowObject = new RowObject()
+        {
+            RowId = expected
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456"
+        };
+        var decorator = FormObjectDecorator.Builder(formObject).CurrentRow(rowObject).Build();
+        Assert.IsTrue(decorator.IsRowPresent(expected));        
+    }
+
+    [TestMethod]
+    public void TestFormObjectDecorator_Builder_OtherRowExpected()
+    {
+        var expected = "456||1";
+        var rowObject = new RowObject()
+        {
+            RowId = expected
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            MultipleIteration = true
+        };
+        var decorator = FormObjectDecorator.Builder(formObject).OtherRow(rowObject).Build();
+        Assert.IsTrue(decorator.IsRowPresent(expected));        
+    }
+
+    [TestMethod]
+    public void TestFormObjectDecorator_Builder_OtherRowsExpected()
+    {
+        var expected = "456||1";
+        var rowObject = new RowObject()
+        {
+            RowId = expected
+        };
+        List<RowObject> rows = [rowObject];
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            MultipleIteration = true
+        };
+        var decorator = FormObjectDecorator.Builder(formObject).OtherRows(rows).Build();
+        Assert.IsTrue(decorator.IsRowPresent(expected));        
+    }
+
+    #endregion
+
     #region GetFieldValue
 
     [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2015DecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2015DecoratorTests.cs
@@ -974,6 +974,122 @@ public class OptionObject2015DecoratorTests
 
     #endregion
 
+    #region IsFormPresent
+
+    [TestMethod]
+    public void IsFormPresent_Expected()
+    {
+        var formObject = new FormObject()
+        {
+            FormId = "123"
+        };
+        var formObject2 = new FormObject()
+        {
+            FormId = "456"
+        };
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject,formObject2]
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        Assert.IsTrue(decorator.IsFormPresent("123"));
+        Assert.IsTrue(decorator.IsFormPresent("456"));
+        Assert.IsFalse(decorator.IsFormPresent("789"));
+    }
+
+    [TestMethod]
+    public void IsFormPresent_NoForms_Expected()
+    {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        Assert.IsFalse(decorator.IsFormPresent("123"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void IsFormPresent_Null()
+    {
+        var formObject = new FormObject()
+        {
+            FormId = "123"
+        };
+        var formObject2 = new FormObject()
+        {
+            FormId = "456"
+        };
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject,formObject2]
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        Assert.IsTrue(decorator.IsFormPresent(null));
+    }
+
+    #endregion
+
+    #region IsRowPresent
+
+    [TestMethod]
+    public void IsRowPresent_Expected()
+    {
+        var rowObject = new RowObject()
+        {
+            RowId = "456||1"
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject]
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        Assert.IsTrue(decorator.IsRowPresent("456||1"));
+    }
+
+    [TestMethod]
+    public void IsRowPresent_NoForms_Expected()
+    {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        Assert.IsFalse(decorator.IsRowPresent("123||1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void IsRowPresent_Null()
+    {
+        var rowObject = new RowObject()
+        {
+            RowId = "456||1"
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject]
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        Assert.IsTrue(decorator.IsRowPresent(null));
+    }
+
+    #endregion
+
     #region SetFieldValue
 
     [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2015DecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2015DecoratorTests.cs
@@ -38,6 +38,167 @@ public class OptionObject2015DecoratorTests
         Assert.AreEqual(0, actual.Forms.Count);
     }
 
+    #region AddFormObject
+
+    [TestMethod]
+    public void AddFormObject_Expected() {
+        var expected = new FormObject() {
+            FormId = "1"
+        };
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectDecorator_Expected() {
+        var expected = FormObjectDecorator.Builder().FormId("1").Build();
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectById_Expected() {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject("1");
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectByIdAndMI_Expected() {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject("1", false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void AddFormObjectByIdAndMI_ArgumentNullException() {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject(null, false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObject_MICannotBeFirst() {
+        var expected = new FormObject() {
+            FormId = "1",
+            MultipleIteration = true
+        };
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectDecorator_MICannotBeFirst() {
+        var expected = FormObjectDecorator.Builder().FormId("1").MultipleIteration().Build();
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectByIdAndMI_MICannotBeFirst() {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject("1", true);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObject_DuplicateForms() {
+        var expected = new FormObject() {
+            FormId = "1"
+        };
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectDecorator_DuplicateForms() {
+        var expected = FormObjectDecorator.Builder().FormId("1").Build();
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectById_DuplicateForms() {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject("1");
+        decorator.AddFormObject("1");
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectByIdAndMI_DuplicateForms() {
+        var optionObject = new OptionObject2015()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2015Decorator(optionObject);
+        decorator.AddFormObject("1", false);
+        decorator.AddFormObject("1", false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    #endregion
+
     #region GetFieldValue
 
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2DecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2DecoratorTests.cs
@@ -974,6 +974,122 @@ public class OptionObject2DecoratorTests
 
     #endregion
 
+    #region IsFormPresent
+
+    [TestMethod]
+    public void IsFormPresent_Expected()
+    {
+        var formObject = new FormObject()
+        {
+            FormId = "123"
+        };
+        var formObject2 = new FormObject()
+        {
+            FormId = "456"
+        };
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject,formObject2]
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        Assert.IsTrue(decorator.IsFormPresent("123"));
+        Assert.IsTrue(decorator.IsFormPresent("456"));
+        Assert.IsFalse(decorator.IsFormPresent("789"));
+    }
+
+    [TestMethod]
+    public void IsFormPresent_NoForms_Expected()
+    {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        Assert.IsFalse(decorator.IsFormPresent("123"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void IsFormPresent_Null()
+    {
+        var formObject = new FormObject()
+        {
+            FormId = "123"
+        };
+        var formObject2 = new FormObject()
+        {
+            FormId = "456"
+        };
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject,formObject2]
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        Assert.IsTrue(decorator.IsFormPresent(null));
+    }
+
+    #endregion
+
+    #region IsRowPresent
+
+    [TestMethod]
+    public void IsRowPresent_Expected()
+    {
+        var rowObject = new RowObject()
+        {
+            RowId = "456||1"
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject]
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        Assert.IsTrue(decorator.IsRowPresent("456||1"));
+    }
+
+    [TestMethod]
+    public void IsRowPresent_NoForms_Expected()
+    {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        Assert.IsFalse(decorator.IsRowPresent("123||1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void IsRowPresent_Null()
+    {
+        var rowObject = new RowObject()
+        {
+            RowId = "456||1"
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject]
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        Assert.IsTrue(decorator.IsRowPresent(null));
+    }
+
+    #endregion
+
     #region SetFieldValue
 
     [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2DecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2DecoratorTests.cs
@@ -38,6 +38,167 @@ public class OptionObject2DecoratorTests
         Assert.AreEqual(0, actual.Forms.Count);
     }
 
+    #region AddFormObject
+
+    [TestMethod]
+    public void AddFormObject_Expected() {
+        var expected = new FormObject() {
+            FormId = "1"
+        };
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectDecorator_Expected() {
+        var expected = FormObjectDecorator.Builder().FormId("1").Build();
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectById_Expected() {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject("1");
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectByIdAndMI_Expected() {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject("1", false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void AddFormObjectByIdAndMI_ArgumentNullException() {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject(null, false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObject_MICannotBeFirst() {
+        var expected = new FormObject() {
+            FormId = "1",
+            MultipleIteration = true
+        };
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectDecorator_MICannotBeFirst() {
+        var expected = FormObjectDecorator.Builder().FormId("1").MultipleIteration().Build();
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectByIdAndMI_MICannotBeFirst() {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject("1", true);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObject_DuplicateForms() {
+        var expected = new FormObject() {
+            FormId = "1"
+        };
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectDecorator_DuplicateForms() {
+        var expected = FormObjectDecorator.Builder().FormId("1").Build();
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject(expected);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectById_DuplicateForms() {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject("1");
+        decorator.AddFormObject("1");
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectByIdAndMI_DuplicateForms() {
+        var optionObject = new OptionObject2()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObject2Decorator(optionObject);
+        decorator.AddFormObject("1", false);
+        decorator.AddFormObject("1", false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    #endregion
+
     #region GetFieldValue
 
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObjectDecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObjectDecoratorTests.cs
@@ -38,6 +38,167 @@ public class OptionObjectDecoratorTests
         Assert.AreEqual(0, actual.Forms.Count);
     }
 
+    #region AddFormObject
+
+    [TestMethod]
+    public void AddFormObject_Expected() {
+        var expected = new FormObject() {
+            FormId = "1"
+        };
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectDecorator_Expected() {
+        var expected = FormObjectDecorator.Builder().FormId("1").Build();
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectById_Expected() {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject("1");
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    public void AddFormObjectByIdAndMI_Expected() {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject("1", false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void AddFormObjectByIdAndMI_ArgumentNullException() {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject(null, false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObject_MICannotBeFirst() {
+        var expected = new FormObject() {
+            FormId = "1",
+            MultipleIteration = true
+        };
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectDecorator_MICannotBeFirst() {
+        var expected = FormObjectDecorator.Builder().FormId("1").MultipleIteration().Build();
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectByIdAndMI_MICannotBeFirst() {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject("1", true);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObject_DuplicateForms() {
+        var expected = new FormObject() {
+            FormId = "1"
+        };
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject(expected);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectDecorator_DuplicateForms() {
+        var expected = FormObjectDecorator.Builder().FormId("1").Build();
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject(expected);
+        decorator.AddFormObject(expected);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectById_DuplicateForms() {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject("1");
+        decorator.AddFormObject("1");
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public void AddFormObjectByIdAndMI_DuplicateForms() {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        decorator.AddFormObject("1", false);
+        decorator.AddFormObject("1", false);
+        Assert.IsTrue(decorator.IsFormPresent("1"));
+    }
+
+    #endregion
+
     #region GetFieldValue
 
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObjectDecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObjectDecoratorTests.cs
@@ -974,6 +974,122 @@ public class OptionObjectDecoratorTests
 
     #endregion
 
+    #region IsFormPresent
+
+    [TestMethod]
+    public void IsFormPresent_Expected()
+    {
+        var formObject = new FormObject()
+        {
+            FormId = "123"
+        };
+        var formObject2 = new FormObject()
+        {
+            FormId = "456"
+        };
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject,formObject2]
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        Assert.IsTrue(decorator.IsFormPresent("123"));
+        Assert.IsTrue(decorator.IsFormPresent("456"));
+        Assert.IsFalse(decorator.IsFormPresent("789"));
+    }
+
+    [TestMethod]
+    public void IsFormPresent_NoForms_Expected()
+    {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        Assert.IsFalse(decorator.IsFormPresent("123"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void IsFormPresent_Null()
+    {
+        var formObject = new FormObject()
+        {
+            FormId = "123"
+        };
+        var formObject2 = new FormObject()
+        {
+            FormId = "456"
+        };
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject,formObject2]
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        Assert.IsTrue(decorator.IsFormPresent(null));
+    }
+
+    #endregion
+
+    #region IsRowPresent
+
+    [TestMethod]
+    public void IsRowPresent_Expected()
+    {
+        var rowObject = new RowObject()
+        {
+            RowId = "456||1"
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject]
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        Assert.IsTrue(decorator.IsRowPresent("456||1"));
+    }
+
+    [TestMethod]
+    public void IsRowPresent_NoForms_Expected()
+    {
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123"
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        Assert.IsFalse(decorator.IsRowPresent("123||1"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void IsRowPresent_Null()
+    {
+        var rowObject = new RowObject()
+        {
+            RowId = "456||1"
+        };
+        var formObject = new FormObject()
+        {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        var optionObject = new OptionObject()
+        {
+            OptionId = "TEST123",
+            Forms = [formObject]
+        };
+        var decorator = new OptionObjectDecorator(optionObject);
+        Assert.IsTrue(decorator.IsRowPresent(null));
+    }
+
+    #endregion
+
     #region SetFieldValue
 
     [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecorator.cs
@@ -30,6 +30,11 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
             return new FormObjectDecoratorBuilder();
         }
 
+        public static FormObjectDecoratorBuilder Builder(FormObject formObject)
+        {
+            return new FormObjectDecoratorBuilder(formObject);
+        }
+
         public FormObjectDecoratorReturnBuilder Return()
         {
             return new FormObjectDecoratorReturnBuilder(this);
@@ -83,6 +88,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         /// <param name="fieldNumber"></param>
         /// <returns></returns>
         public bool IsFieldRequired(string fieldNumber) => Helper.IsFieldRequired(this, fieldNumber);
+
+        /// <summary>
+        /// Determines whether the <see cref="RowObject"/> is present in the <see cref="FormObject"/> by RowId.
+        /// </summary>
+        /// <param name="fieldNumber"></param>
+        /// <returns></returns>
+        public bool IsRowPresent(string rowId) => Helper.IsRowPresent(this, rowId);
         
         /// <summary>
         /// Sets the value of a <see cref="FieldObject"/> in the <see cref="CurrentRow"/> of a <see cref="FormObject"/>.

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecorator.cs
@@ -25,6 +25,11 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         public string FormId => _formObject.FormId;
         public bool MultipleIteration => _formObject.MultipleIteration;
 
+        public static FormObjectDecoratorBuilder Builder()
+        {
+            return new FormObjectDecoratorBuilder();
+        }
+
         public FormObjectDecoratorReturnBuilder Return()
         {
             return new FormObjectDecoratorReturnBuilder(this);

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorBuilder.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorBuilder.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using RarelySimple.AvatarScriptLink.Objects;
+
+namespace RarelySimple.AvatarScriptLink.Net.Decorators
+{
+    public sealed partial class FormObjectDecorator
+    {
+        public class FormObjectDecoratorBuilder
+        {
+            private string _formId;
+            private RowObject _currentRow;
+            private bool _multipleIteration;
+            private List<RowObject> _otherRows;
+
+            public FormObjectDecoratorBuilder() {
+                _otherRows = new List<RowObject>();
+            }
+
+            public FormObjectDecoratorBuilder(FormObject formObject) {
+                if (formObject != null) {
+                    _formId = formObject.FormId;
+                    _currentRow = formObject.CurrentRow;
+                    _multipleIteration = formObject.MultipleIteration;
+                    _otherRows = formObject.OtherRows;
+                }
+            }
+
+            public FormObjectDecoratorBuilder CurrentRow(RowObject rowObject) {
+                _currentRow = rowObject;
+                return this;
+            }
+
+            public FormObjectDecoratorBuilder FormId(string formId) {
+                _formId = formId;
+                return this;
+            }
+
+            public FormObjectDecoratorBuilder MultipleIteration() {
+                _multipleIteration = true;
+                return this;
+            }
+
+            public FormObjectDecoratorBuilder MultipleIteration(bool multipleIteration) {
+                _multipleIteration = multipleIteration;
+                return this;
+            }
+
+            public FormObjectDecoratorBuilder OtherRow(RowObject rowObject) {
+                if (rowObject != null) {
+                    _otherRows.Add(rowObject);
+                }
+                return this;
+            }
+
+            public FormObjectDecoratorBuilder OtherRows(List<RowObject> rowObjects) {
+                _otherRows = rowObjects;
+                return this;
+            }
+
+            public FormObjectDecorator Build() {
+                FormObject formObject = new FormObject {
+                    FormId = _formId,
+                    CurrentRow = _currentRow,
+                    MultipleIteration = _multipleIteration,
+                    OtherRows = _otherRows
+                };
+                return new FormObjectDecorator(formObject);
+            }
+        }
+    }
+}

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorHelper.cs
@@ -13,7 +13,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
             /// <summary>
-            /// Returns the FieldValue of a <see cref="FieldObject"/> in the curent row of a <see cref="FormObjectDecorator"/> by FieldNumber.
+            /// Returns the FieldValue of a <see cref="FieldObjectDecorator"/> in the curent row of a <see cref="FormObjectDecorator"/> by FieldNumber.
             /// </summary>
             /// <param name="formObject"></param>
             /// <param name="fieldNumber"></param>
@@ -25,7 +25,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return GetFieldValue(formObject, formObject.CurrentRow.RowId, fieldNumber);
             }
             /// <summary>
-            /// Returns the FieldValue of a <see cref="FieldObject"/> in a <see cref="FormObjectDecorator"/> by RowId and FieldNumber.
+            /// Returns the FieldValue of a <see cref="FieldObjectDecorator"/> in a <see cref="FormObjectDecorator"/> by RowId and FieldNumber.
             /// </summary>
             /// <param name="formObject"></param>
             /// <param name="rowId"></param>
@@ -49,7 +49,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
             /// <summary>
-            /// Returns whether a <see cref="FormObject"/> is Multiple Iteration.
+            /// Returns whether a <see cref="FormObjectDecorator"/> is Multiple Iteration.
             /// </summary>
             /// <param name="formObject"></param>
             /// <returns></returns>
@@ -60,7 +60,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return formObject.MultipleIteration;
             }
             /// <summary>
-            /// Returns whether the <see cref="IFieldObject"/> in the <see cref="IFormObject"/> is enabled by FieldNumber.
+            /// Returns whether the <see cref="IFieldObject"/> in the <see cref="FormObjectDecorator"/> is enabled by FieldNumber.
             /// </summary>
             /// <param name="formObject"></param>
             /// <param name="fieldNumber"></param>
@@ -76,7 +76,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return RowObjectDecorator.Helper.IsFieldEnabled(formObject.CurrentRow, fieldNumber);
             }
             /// <summary>
-            /// Returns whether the <see cref="IFieldObject"/> in the <see cref="IFormObject"/> is locked by FieldNumber.
+            /// Returns whether the <see cref="FieldObjectDecorator"/> in the <see cref="FormObjectDecorator"/> is locked by FieldNumber.
             /// </summary>
             /// <param name="formObject"></param>
             /// <param name="fieldNumber"></param>
@@ -108,7 +108,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return RowObjectDecorator.Helper.IsFieldPresent(decorator.CurrentRow, fieldNumber);
             }
             /// <summary>
-            /// Returns whether the <see cref="IFieldObject"/> in the <see cref="IFormObject"/> is required by FieldNumber.
+            /// Returns whether the <see cref="FieldObjectDecorator"/> in the <see cref="FormObjectDecorator"/> is required by FieldNumber.
             /// </summary>
             /// <param name="formObject"></param>
             /// <param name="fieldNumber"></param>
@@ -124,7 +124,25 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return RowObjectDecorator.Helper.IsFieldRequired(formObject.CurrentRow, fieldNumber);
             }
             /// <summary>
-            /// Sets the FieldValue of a <see cref="FieldObject"/> in a <see cref="IFormObject"/> by FieldNumber.
+            /// Returns whether the <see cref="RowObjectDecorator"/> in the <see cref="FormObjectDecorator"/> is enabled by RowId.
+            /// </summary>
+            /// <param name="formObject"></param>
+            /// <param name="rowId"></param>
+            /// <returns></returns>
+            public static bool IsRowPresent(FormObjectDecorator formObject, string rowId)
+            {
+                if (formObject == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (string.IsNullOrEmpty(rowId))
+                    throw new ArgumentNullException(nameof(rowId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formObject.CurrentRow != null && formObject.CurrentRow.RowId == rowId)
+                    return true;
+                if (formObject.MultipleIteration)
+                    return formObject.OtherRows.Exists(r => r.RowId == rowId);
+                return false;
+            }
+            /// <summary>
+            /// Sets the FieldValue of a <see cref="FieldObjectDecorator"/> in a <see cref="FormObjectDecorator"/> by FieldNumber.
             /// </summary>
             /// <param name="decorator"></param>
             /// <param name="fieldNumber"></param>
@@ -143,7 +161,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return SetFieldValue(decorator, decorator.CurrentRow.RowId, fieldNumber, fieldValue);
             }
             /// <summary>
-            /// Sets the FieldValue of a <see cref="FieldObject"/> in a <see cref="IFormObject"/> by RowId and FieldNumber.
+            /// Sets the FieldValue of a <see cref="FieldObjectDecorator"/> in a <see cref="FormObjectDecorator"/> by RowId and FieldNumber.
             /// </summary>
             /// <param name="decorator"></param>
             /// <param name="rowId"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorReturnBuilder.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorReturnBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using RarelySimple.AvatarScriptLink.Objects;
+﻿using RarelySimple.AvatarScriptLink.Objects;
 
 namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015Decorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015Decorator.cs
@@ -122,6 +122,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         public bool IsFormPresent(string formId) => Helper.IsFormPresent(this, formId);
 
         /// <summary>
+        /// Returns whether the specified <see cref="RowObject"/> is present.
+        /// </summary>
+        /// <param name="rowId"></param>
+        /// <returns></returns>
+        public bool IsRowPresent(string rowId) => Helper.IsRowPresent(this, rowId);
+
+        /// <summary>
         /// Sets the FieldValue of a <see cref="FieldObject"/> in the <see cref="OptionObject2015Decorator"/> on the first form CurrentRow.
         /// </summary>
         /// <param name="fieldNumber"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015Decorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015Decorator.cs
@@ -41,6 +41,31 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         }
 
         /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2015Decorator"/>.
+        /// </summary>
+        /// <param name="formObject"></param>
+        public void AddFormObject(FormObject formObject) => Forms = Helper.AddFormObject(this, formObject).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObjectDecorator"/> to an <see cref="OptionObject2015Decorator"/>.
+        /// </summary>
+        /// <param name="formObject"></param>
+        public void AddFormObject(FormObjectDecorator formObject) => Forms = Helper.AddFormObject(this, formObject).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2015Decorator"/>.
+        /// </summary>
+        /// <param name="formId"></param>
+        public void AddFormObject(string formId) => Forms = Helper.AddFormObject(this, formId).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2015Decorator"/>.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <param name="multipleIteration"></param>
+        public void AddFormObject(string formId, bool multipleIteration) => Forms = Helper.AddFormObject(this, formId, multipleIteration).Forms;
+
+        /// <summary>
         /// Returns the first value of the field matching the Field Number.
         /// </summary>
         /// <param name="fieldNumber"></param>
@@ -88,6 +113,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         /// <param name="fieldNumber"></param>
         /// <returns></returns>
         public bool IsFieldRequired(string fieldNumber) => Helper.IsFieldRequired(this, fieldNumber);
+
+        /// <summary>
+        /// Returns whether the specified <see cref="FormObject"/> is present.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <returns></returns>
+        public bool IsFormPresent(string formId) => Helper.IsFormPresent(this, formId);
 
         /// <summary>
         /// Sets the FieldValue of a <see cref="FieldObject"/> in the <see cref="OptionObject2015Decorator"/> on the first form CurrentRow.

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Resources;
 using RarelySimple.AvatarScriptLink.Net.Exceptions;
+using RarelySimple.AvatarScriptLink.Objects;
 
 namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
@@ -12,6 +13,75 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formObject"></param>
+            /// <returns></returns>
+            public static OptionObject2015Decorator AddFormObject(OptionObject2015Decorator optionObject, FormObject formObject)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formObject == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                return AddFormObject(optionObject, new FormObjectDecorator(formObject));
+            }
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2015"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formObject"></param>
+            /// <returns></returns>
+            public static OptionObject2015Decorator AddFormObject(OptionObject2015Decorator optionObject, FormObjectDecorator formObject)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formObject == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (optionObject.Forms.Count == 0 && formObject.MultipleIteration)
+                    throw new ArgumentException(resourceManager.GetString("firstFormCannotBeMultipleIteration", CultureInfo.CurrentCulture));
+                if (optionObject.Forms.Contains(formObject) || optionObject.Forms.Exists(f => f.FormId == formObject.FormId))
+                    throw new ArgumentException(resourceManager.GetString("formIdAlreadyExists", CultureInfo.CurrentCulture));
+                optionObject.Forms.Add(formObject);
+                return optionObject;
+            }
+            /// <summary>
+            /// Creates a <see cref="FormObject"/> with specified FormId and adds to an <see cref="OptionObject2015"/> using provided FormId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static OptionObject2015Decorator AddFormObject(OptionObject2015Decorator optionObject, string formId)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formId == null)
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                FormObjectDecorator formObject = FormObjectDecorator.Builder()
+                    .FormId(formId)
+                    .Build();
+                return AddFormObject(optionObject, formObject);
+            }
+            /// <summary>
+            /// Creates a <see cref="FormObject"/> with specified FormId and adds to an <see cref="OptionObject2015"/> using provided FormId and indicating whether it is a multiple iteration table.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <param name="multipleIteration"></param>
+            /// <returns></returns>
+            public static OptionObject2015Decorator AddFormObject(OptionObject2015Decorator optionObject, string formId, bool multipleIteration)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formId == null)
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                FormObjectDecorator formObject = FormObjectDecorator.Builder()
+                    .FormId(formId)
+                    .MultipleIteration(multipleIteration)
+                    .Build();
+                return AddFormObject(optionObject, formObject);
+            }
             /// <summary>
             /// Returns the FieldValue of a specified <see cref="FieldObject"/> in an <see cref="OptionObject2015Decorator"/> by FieldNumber.
             /// </summary>
@@ -155,6 +225,22 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     return FormObjectDecorator.Helper.IsFieldRequired(form, fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
+            }
+            /// <summary>
+            /// Returns whether a <see cref="FormObject"/> exists in an <see cref="OptionObject2015Decorator"/> by <see cref="FormObject.FormId"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static bool IsFormPresent(OptionObject2015Decorator optionObject, string formId)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (optionObject.Forms == null || optionObject.Forms.Count == 0)
+                    return false;
+                return optionObject.Forms.Exists(f => f.FormId == formId);
             }
             /// <summary>
             /// Sets the FieldValue of a <see cref="FieldObject"/> in an <see cref="OptionObject2015Decorator"/> by FieldNumber.

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
@@ -243,6 +243,20 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return optionObject.Forms.Exists(f => f.FormId == formId);
             }
             /// <summary>
+            /// Returns whether the <see cref="RowObject"/> in the <see cref="OptionObject2015Decorator"/> is enabled by RowId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="rowId"></param>
+            /// <returns></returns>
+            public static bool IsRowPresent(OptionObject2015Decorator optionObject, string rowId)
+            {
+                if (optionObject.Forms == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString("optionObjectMissingForms", CultureInfo.CurrentCulture));
+                if (string.IsNullOrEmpty(rowId))
+                    throw new ArgumentNullException(nameof(rowId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                return optionObject.Forms.Find(x => x.IsRowPresent(rowId)) != null;
+            }
+            /// <summary>
             /// Sets the FieldValue of a <see cref="FieldObject"/> in an <see cref="OptionObject2015Decorator"/> by FieldNumber.
             /// </summary>
             /// <param name="decorator"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
@@ -250,8 +250,6 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
             /// <returns></returns>
             public static bool IsRowPresent(OptionObject2015Decorator optionObject, string rowId)
             {
-                if (optionObject.Forms == null)
-                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString("optionObjectMissingForms", CultureInfo.CurrentCulture));
                 if (string.IsNullOrEmpty(rowId))
                     throw new ArgumentNullException(nameof(rowId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 return optionObject.Forms.Find(x => x.IsRowPresent(rowId)) != null;

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2Decorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2Decorator.cs
@@ -121,6 +121,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         public bool IsFormPresent(string formId) => Helper.IsFormPresent(this, formId);
 
         /// <summary>
+        /// Returns whether the specified <see cref="RowObject"/> is present.
+        /// </summary>
+        /// <param name="rowId"></param>
+        /// <returns></returns>
+        public bool IsRowPresent(string rowId) => Helper.IsRowPresent(this, rowId);
+
+        /// <summary>
         /// Sets the FieldValue of a <see cref="FieldObject"/> in the <see cref="OptionObject2Decorator"/> on the first form CurrentRow.
         /// </summary>
         /// <param name="fieldNumber"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2Decorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2Decorator.cs
@@ -40,6 +40,31 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         }
 
         /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2Decorator"/>.
+        /// </summary>
+        /// <param name="formObject"></param>
+        public void AddFormObject(FormObject formObject) => Forms = Helper.AddFormObject(this, formObject).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObjectDecorator"/> to an <see cref="OptionObject2Decorator"/>.
+        /// </summary>
+        /// <param name="formObject"></param>
+        public void AddFormObject(FormObjectDecorator formObject) => Forms = Helper.AddFormObject(this, formObject).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2Decorator"/>.
+        /// </summary>
+        /// <param name="formId"></param>
+        public void AddFormObject(string formId) => Forms = Helper.AddFormObject(this, formId).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2Decorator"/>.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <param name="multipleIteration"></param>
+        public void AddFormObject(string formId, bool multipleIteration) => Forms = Helper.AddFormObject(this, formId, multipleIteration).Forms;
+
+        /// <summary>
         /// Returns the first value of the field matching the Field Number.
         /// </summary>
         /// <param name="fieldNumber"></param>
@@ -87,6 +112,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         /// <param name="fieldNumber"></param>
         /// <returns></returns>
         public bool IsFieldRequired(string fieldNumber) => Helper.IsFieldRequired(this, fieldNumber);
+
+        /// <summary>
+        /// Returns whether the specified <see cref="FormObject"/> is present.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <returns></returns>
+        public bool IsFormPresent(string formId) => Helper.IsFormPresent(this, formId);
 
         /// <summary>
         /// Sets the FieldValue of a <see cref="FieldObject"/> in the <see cref="OptionObject2Decorator"/> on the first form CurrentRow.

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Resources;
 using RarelySimple.AvatarScriptLink.Net.Exceptions;
+using RarelySimple.AvatarScriptLink.Objects;
 
 namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
@@ -12,6 +13,75 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formObject"></param>
+            /// <returns></returns>
+            public static OptionObject2Decorator AddFormObject(OptionObject2Decorator optionObject, FormObject formObject)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formObject == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                return AddFormObject(optionObject, new FormObjectDecorator(formObject));
+            }
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject2"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formObject"></param>
+            /// <returns></returns>
+            public static OptionObject2Decorator AddFormObject(OptionObject2Decorator optionObject, FormObjectDecorator formObject)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formObject == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (optionObject.Forms.Count == 0 && formObject.MultipleIteration)
+                    throw new ArgumentException(resourceManager.GetString("firstFormCannotBeMultipleIteration", CultureInfo.CurrentCulture));
+                if (optionObject.Forms.Contains(formObject) || optionObject.Forms.Exists(f => f.FormId == formObject.FormId))
+                    throw new ArgumentException(resourceManager.GetString("formIdAlreadyExists", CultureInfo.CurrentCulture));
+                optionObject.Forms.Add(formObject);
+                return optionObject;
+            }
+            /// <summary>
+            /// Creates a <see cref="FormObject"/> with specified FormId and adds to an <see cref="OptionObject2"/> using provided FormId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static OptionObject2Decorator AddFormObject(OptionObject2Decorator optionObject, string formId)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formId == null)
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                FormObjectDecorator formObject = FormObjectDecorator.Builder()
+                    .FormId(formId)
+                    .Build();
+                return AddFormObject(optionObject, formObject);
+            }
+            /// <summary>
+            /// Creates a <see cref="FormObject"/> with specified FormId and adds to an <see cref="OptionObject2"/> using provided FormId and indicating whether it is a multiple iteration table.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <param name="multipleIteration"></param>
+            /// <returns></returns>
+            public static OptionObject2Decorator AddFormObject(OptionObject2Decorator optionObject, string formId, bool multipleIteration)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formId == null)
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                FormObjectDecorator formObject = FormObjectDecorator.Builder()
+                    .FormId(formId)
+                    .MultipleIteration(multipleIteration)
+                    .Build();
+                return AddFormObject(optionObject, formObject);
+            }
             /// <summary>
             /// Returns the FieldValue of a specified <see cref="FieldObject"/> in an <see cref="OptionObject2Decorator"/> by FieldNumber.
             /// </summary>
@@ -155,6 +225,22 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     return FormObjectDecorator.Helper.IsFieldRequired(form, fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
+            }
+            /// <summary>
+            /// Returns whether a <see cref="FormObject"/> exists in an <see cref="OptionObject2Decorator"/> by <see cref="FormObject.FormId"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static bool IsFormPresent(OptionObject2Decorator optionObject, string formId)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (optionObject.Forms == null || optionObject.Forms.Count == 0)
+                    return false;
+                return optionObject.Forms.Exists(f => f.FormId == formId);
             }
             /// <summary>
             /// Sets the FieldValue of a <see cref="FieldObject"/> in an <see cref="OptionObject2Decorator"/> by FieldNumber.

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
@@ -250,8 +250,6 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
             /// <returns></returns>
             public static bool IsRowPresent(OptionObject2Decorator optionObject, string rowId)
             {
-                if (optionObject.Forms == null)
-                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString("optionObjectMissingForms", CultureInfo.CurrentCulture));
                 if (string.IsNullOrEmpty(rowId))
                     throw new ArgumentNullException(nameof(rowId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 return optionObject.Forms.Find(x => x.IsRowPresent(rowId)) != null;

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
@@ -243,6 +243,20 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return optionObject.Forms.Exists(f => f.FormId == formId);
             }
             /// <summary>
+            /// Returns whether the <see cref="RowObject"/> in the <see cref="OptionObject2Decorator"/> is enabled by RowId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="rowId"></param>
+            /// <returns></returns>
+            public static bool IsRowPresent(OptionObject2Decorator optionObject, string rowId)
+            {
+                if (optionObject.Forms == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString("optionObjectMissingForms", CultureInfo.CurrentCulture));
+                if (string.IsNullOrEmpty(rowId))
+                    throw new ArgumentNullException(nameof(rowId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                return optionObject.Forms.Find(x => x.IsRowPresent(rowId)) != null;
+            }
+            /// <summary>
             /// Sets the FieldValue of a <see cref="FieldObject"/> in an <see cref="OptionObject2Decorator"/> by FieldNumber.
             /// </summary>
             /// <param name="decorator"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecorator.cs
@@ -37,6 +37,31 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         }
 
         /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObjectDecorator"/>.
+        /// </summary>
+        /// <param name="formObject"></param>
+        public void AddFormObject(FormObject formObject) => Forms = Helper.AddFormObject(this, formObject).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObjectDecorator"/> to an <see cref="OptionObjectDecorator"/>.
+        /// </summary>
+        /// <param name="formObject"></param>
+        public void AddFormObject(FormObjectDecorator formObject) => Forms = Helper.AddFormObject(this, formObject).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObjectDecorator"/>.
+        /// </summary>
+        /// <param name="formId"></param>
+        public void AddFormObject(string formId) => Forms = Helper.AddFormObject(this, formId).Forms;
+
+        /// <summary>
+        /// Adds a <see cref="FormObject"/> to an <see cref="OptionObjectDecorator"/>.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <param name="multipleIteration"></param>
+        public void AddFormObject(string formId, bool multipleIteration) => Forms = Helper.AddFormObject(this, formId, multipleIteration).Forms;
+
+        /// <summary>
         /// Returns the first value of the field matching the Field Number.
         /// </summary>
         /// <param name="fieldNumber"></param>
@@ -84,6 +109,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         /// <param name="fieldNumber"></param>
         /// <returns></returns>
         public bool IsFieldRequired(string fieldNumber) => Helper.IsFieldRequired(this, fieldNumber);
+
+        /// <summary>
+        /// Returns whether the specified <see cref="FormObject"/> is present.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <returns></returns>
+        public bool IsFormPresent(string formId) => Helper.IsFormPresent(this, formId);
 
         /// <summary>
         /// Sets the FieldValue of a <see cref="FieldObject"/> in the <see cref="OptionObjectDecorator"/> on the first form CurrentRow.

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecorator.cs
@@ -118,6 +118,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         public bool IsFormPresent(string formId) => Helper.IsFormPresent(this, formId);
 
         /// <summary>
+        /// Returns whether the specified <see cref="RowObject"/> is present.
+        /// </summary>
+        /// <param name="rowId"></param>
+        /// <returns></returns>
+        public bool IsRowPresent(string rowId) => Helper.IsRowPresent(this, rowId);
+
+        /// <summary>
         /// Sets the FieldValue of a <see cref="FieldObject"/> in the <see cref="OptionObjectDecorator"/> on the first form CurrentRow.
         /// </summary>
         /// <param name="fieldNumber"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
@@ -250,8 +250,6 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
             /// <returns></returns>
             public static bool IsRowPresent(OptionObjectDecorator optionObject, string rowId)
             {
-                if (optionObject.Forms == null)
-                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString("optionObjectMissingForms", CultureInfo.CurrentCulture));
                 if (string.IsNullOrEmpty(rowId))
                     throw new ArgumentNullException(nameof(rowId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 return optionObject.Forms.Find(x => x.IsRowPresent(rowId)) != null;

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
@@ -243,6 +243,20 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return optionObject.Forms.Exists(f => f.FormId == formId);
             }
             /// <summary>
+            /// Returns whether the <see cref="RowObject"/> in the <see cref="OptionObjectDecorator"/> is enabled by RowId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="rowId"></param>
+            /// <returns></returns>
+            public static bool IsRowPresent(OptionObjectDecorator optionObject, string rowId)
+            {
+                if (optionObject.Forms == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString("optionObjectMissingForms", CultureInfo.CurrentCulture));
+                if (string.IsNullOrEmpty(rowId))
+                    throw new ArgumentNullException(nameof(rowId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                return optionObject.Forms.Find(x => x.IsRowPresent(rowId)) != null;
+            }
+            /// <summary>
             /// Sets the FieldValue of a <see cref="FieldObject"/> in an <see cref="OptionObjectDecorator"/> by FieldNumber.
             /// </summary>
             /// <param name="decorator"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Resources;
 using RarelySimple.AvatarScriptLink.Net.Exceptions;
+using RarelySimple.AvatarScriptLink.Objects;
 
 namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
@@ -12,6 +13,75 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formObject"></param>
+            /// <returns></returns>
+            public static OptionObjectDecorator AddFormObject(OptionObjectDecorator optionObject, FormObject formObject)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formObject == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                return AddFormObject(optionObject, new FormObjectDecorator(formObject));
+            }
+            /// <summary>
+            /// Adds a <see cref="FormObject"/> to an <see cref="OptionObject"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formObject"></param>
+            /// <returns></returns>
+            public static OptionObjectDecorator AddFormObject(OptionObjectDecorator optionObject, FormObjectDecorator formObject)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formObject == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (optionObject.Forms.Count == 0 && formObject.MultipleIteration)
+                    throw new ArgumentException(resourceManager.GetString("firstFormCannotBeMultipleIteration", CultureInfo.CurrentCulture));
+                if (optionObject.Forms.Contains(formObject) || optionObject.Forms.Exists(f => f.FormId == formObject.FormId))
+                    throw new ArgumentException(resourceManager.GetString("formIdAlreadyExists", CultureInfo.CurrentCulture));
+                optionObject.Forms.Add(formObject);
+                return optionObject;
+            }
+            /// <summary>
+            /// Creates a <see cref="FormObject"/> with specified FormId and adds to an <see cref="OptionObject"/> using provided FormId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static OptionObjectDecorator AddFormObject(OptionObjectDecorator optionObject, string formId)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formId == null)
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                FormObjectDecorator formObject = FormObjectDecorator.Builder()
+                    .FormId(formId)
+                    .Build();
+                return AddFormObject(optionObject, formObject);
+            }
+            /// <summary>
+            /// Creates a <see cref="FormObject"/> with specified FormId and adds to an <see cref="OptionObject"/> using provided FormId and indicating whether it is a multiple iteration table.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <param name="multipleIteration"></param>
+            /// <returns></returns>
+            public static OptionObjectDecorator AddFormObject(OptionObjectDecorator optionObject, string formId, bool multipleIteration)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (formId == null)
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                FormObjectDecorator formObject = FormObjectDecorator.Builder()
+                    .FormId(formId)
+                    .MultipleIteration(multipleIteration)
+                    .Build();
+                return AddFormObject(optionObject, formObject);
+            }
             /// <summary>
             /// Returns the FieldValue of a specified <see cref="FieldObject"/> in an <see cref="OptionObjectDecorator"/> by FieldNumber.
             /// </summary>
@@ -155,6 +225,22 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     return FormObjectDecorator.Helper.IsFieldRequired(form, fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
+            }
+            /// <summary>
+            /// Returns whether a <see cref="FormObject"/> exists in an <see cref="OptionObjectDecorator"/> by <see cref="FormObject.FormId"/>.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static bool IsFormPresent(OptionObjectDecorator optionObject, string formId)
+            {
+                if (optionObject == null)
+                    throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                if (optionObject.Forms == null || optionObject.Forms.Count == 0)
+                    return false;
+                return optionObject.Forms.Exists(f => f.FormId == formId);
             }
             /// <summary>
             /// Sets the FieldValue of a <see cref="FieldObject"/> in an <see cref="OptionObjectDecorator"/> by FieldNumber.


### PR DESCRIPTION
This update adds the `AddFormObject` and `IsFormPresent` methods to the new .NET package.

This adds new options:

- AddFormObject using a FormObject or a FormObjectDecorator
- AddFormObject with just the FormId to add an empty non-Multiple Iteration FormObject.

This also introduces a FormObjectDecorator Builder class to assist with various use cases like unit testing.