### PR TITLE
Implement GetCurrentRowId

### DIFF
--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/FormObjectDecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/FormObjectDecoratorTests.cs
@@ -118,6 +118,28 @@ public class FormObjectDecoratorTests
 
     #endregion
 
+    #region GetCurrentRowId
+
+    [TestMethod]
+    public void TestFormObjectDecorator_GetCurrentRowId_Expected() {
+        var expected = "456||1";
+        RowObject rowObject = new() {
+            RowId = expected
+        };
+        FormObjectDecorator decorator = FormObjectDecorator.Builder().FormId("456").CurrentRow(rowObject).Build();
+        Assert.AreEqual(expected, decorator.GetCurrentRowId());
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void TestFormObjectDecorator_GetCurrentRowId_Exception() {
+        var expected = "456||1";
+        FormObjectDecorator decorator = FormObjectDecorator.Builder().FormId("456").Build();
+        Assert.AreEqual(expected, decorator.GetCurrentRowId());
+    }
+
+    #endregion
+
     #region GetFieldValue
 
     [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2015DecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2015DecoratorTests.cs
@@ -199,6 +199,43 @@ public class OptionObject2015DecoratorTests
 
     #endregion
 
+    #region GetCurrentRowId
+
+    [TestMethod]
+    public void TestOptionObject2015Decorator_GetCurrentRowId_Expected() {
+        var expected = "456||1";
+        RowObject rowObject = new() {
+            RowId = expected
+        };
+        FormObject formObject = new() {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        OptionObject2015 optionObject = new() {
+            OptionId = "USER123",
+            Forms = [formObject]
+        };
+        OptionObject2015Decorator decorator = new(optionObject);
+        Assert.AreEqual(expected, decorator.GetCurrentRowId("456"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void TestOptionObject2015Decorator_GetCurrentRowId_Exception() {
+        var expected = "456||1";
+        FormObject formObject = new() {
+            FormId = "456"
+        };
+        OptionObject2015 optionObject = new() {
+            OptionId = "USER123",
+            Forms = [formObject]
+        };
+        OptionObject2015Decorator decorator = new(optionObject);
+        Assert.AreEqual(expected, decorator.GetCurrentRowId("456"));
+    }
+
+    #endregion
+
     #region GetFieldValue
 
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2DecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObject2DecoratorTests.cs
@@ -199,6 +199,43 @@ public class OptionObject2DecoratorTests
 
     #endregion
 
+    #region GetCurrentRowId
+
+    [TestMethod]
+    public void TestOptionObject2Decorator_GetCurrentRowId_Expected() {
+        var expected = "456||1";
+        RowObject rowObject = new() {
+            RowId = expected
+        };
+        FormObject formObject = new() {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        OptionObject2 optionObject = new() {
+            OptionId = "USER123",
+            Forms = [formObject]
+        };
+        OptionObject2Decorator decorator = new(optionObject);
+        Assert.AreEqual(expected, decorator.GetCurrentRowId("456"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void TestOptionObject2Decorator_GetCurrentRowId_Exception() {
+        var expected = "456||1";
+        FormObject formObject = new() {
+            FormId = "456"
+        };
+        OptionObject2 optionObject = new() {
+            OptionId = "USER123",
+            Forms = [formObject]
+        };
+        OptionObject2Decorator decorator = new(optionObject);
+        Assert.AreEqual(expected, decorator.GetCurrentRowId("456"));
+    }
+
+    #endregion
+
     #region GetFieldValue
 
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObjectDecoratorTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net.Tests/Decorators/OptionObjectDecoratorTests.cs
@@ -199,6 +199,43 @@ public class OptionObjectDecoratorTests
 
     #endregion
 
+    #region GetCurrentRowId
+
+    [TestMethod]
+    public void TestOptionObjectDecorator_GetCurrentRowId_Expected() {
+        var expected = "456||1";
+        RowObject rowObject = new() {
+            RowId = expected
+        };
+        FormObject formObject = new() {
+            FormId = "456",
+            CurrentRow = rowObject
+        };
+        OptionObject optionObject = new() {
+            OptionId = "USER123",
+            Forms = [formObject]
+        };
+        OptionObjectDecorator decorator = new(optionObject);
+        Assert.AreEqual(expected, decorator.GetCurrentRowId("456"));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void TestOptionObjectDecorator_GetCurrentRowId_Exception() {
+        var expected = "456||1";
+        FormObject formObject = new() {
+            FormId = "456"
+        };
+        OptionObject optionObject = new() {
+            OptionId = "USER123",
+            Forms = [formObject]
+        };
+        OptionObjectDecorator decorator = new(optionObject);
+        Assert.AreEqual(expected, decorator.GetCurrentRowId("456"));
+    }
+
+    #endregion
+
     #region GetFieldValue
 
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecorator.cs
@@ -41,6 +41,12 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         }
 
         /// <summary>
+        /// Returns the RowId of the <see cref="CurrentRow"/>.
+        /// </summary>
+        /// <returns></returns>
+        public string GetCurrentRowId() => Helper.GetCurrentRowId(this);
+
+        /// <summary>
         /// Returns the value of the <see cref="FieldObject"/> in the CurrentRow of the <see cref="FormObject"/> by FieldNumber.
         /// </summary>
         /// <param name="fieldNumber"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/FormObjectDecoratorHelper.cs
@@ -8,10 +8,21 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
     public sealed partial class FormObjectDecorator
     {
-        public class Helper : DecoratorHelper
+        private sealed class Helper : DecoratorHelper
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
+            /// <summary>
+            /// Gets the CurrentRow.RowId of the <see cref="FormObjectDecorator"/>.
+            /// </summary>
+            /// <param name="formObject"></param>
+            /// <returns></returns>
+            public static string GetCurrentRowId(FormObjectDecorator formObject)
+            {
+                if (formObject.CurrentRow == null)
+                    throw new ArgumentNullException(nameof(formObject), resourceManager.GetString("formObjectMissingCurrentRow", CultureInfo.CurrentCulture));
+                return formObject.CurrentRow.RowId;
+            }
             /// <summary>
             /// Returns the FieldValue of a <see cref="FieldObjectDecorator"/> in the curent row of a <see cref="FormObjectDecorator"/> by FieldNumber.
             /// </summary>
@@ -40,11 +51,11 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 if (string.IsNullOrEmpty(fieldNumber))
                     throw new ArgumentNullException(nameof(fieldNumber), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 if (formObject.CurrentRow.RowId == rowId)
-                    return RowObjectDecorator.Helper.GetFieldValue(formObject.CurrentRow, fieldNumber);
+                    return formObject.CurrentRow.GetFieldValue(fieldNumber);
                 foreach (RowObjectDecorator rowObject in formObject.OtherRows)
                 {
                     if (rowObject.RowId == rowId)
-                        return RowObjectDecorator.Helper.GetFieldValue(rowObject, fieldNumber);
+                        return rowObject.GetFieldValue(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -73,7 +84,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(FormObjectMissingCurrentRow, CultureInfo.CurrentCulture));
                 if (string.IsNullOrEmpty(fieldNumber))
                     throw new ArgumentNullException(nameof(fieldNumber), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
-                return RowObjectDecorator.Helper.IsFieldEnabled(formObject.CurrentRow, fieldNumber);
+                return formObject.CurrentRow.IsFieldEnabled(fieldNumber);
             }
             /// <summary>
             /// Returns whether the <see cref="FieldObjectDecorator"/> in the <see cref="FormObjectDecorator"/> is locked by FieldNumber.
@@ -89,7 +100,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(FormObjectMissingCurrentRow, CultureInfo.CurrentCulture));
                 if (string.IsNullOrEmpty(fieldNumber))
                     throw new ArgumentNullException(nameof(fieldNumber), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
-                return RowObjectDecorator.Helper.IsFieldLocked(formObject.CurrentRow, fieldNumber);
+                return formObject.CurrentRow.IsFieldLocked(fieldNumber);
             }
             /// <summary>
             /// Returns whether the <see cref="FieldObjectDecorator"/> in the <see cref="FormObjectDecorator"/> is present by FieldNumber.
@@ -105,7 +116,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(fieldNumber), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 if (decorator.CurrentRow == null)
                     return false;
-                return RowObjectDecorator.Helper.IsFieldPresent(decorator.CurrentRow, fieldNumber);
+                return decorator.CurrentRow.IsFieldPresent(fieldNumber);
             }
             /// <summary>
             /// Returns whether the <see cref="FieldObjectDecorator"/> in the <see cref="FormObjectDecorator"/> is required by FieldNumber.
@@ -121,7 +132,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(formObject), resourceManager.GetString(FormObjectMissingCurrentRow, CultureInfo.CurrentCulture));
                 if (string.IsNullOrEmpty(fieldNumber))
                     throw new ArgumentNullException(nameof(fieldNumber), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
-                return RowObjectDecorator.Helper.IsFieldRequired(formObject.CurrentRow, fieldNumber);
+                return formObject.CurrentRow.IsFieldRequired(fieldNumber);
             }
             /// <summary>
             /// Returns whether the <see cref="RowObjectDecorator"/> in the <see cref="FormObjectDecorator"/> is enabled by RowId.
@@ -180,7 +191,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(fieldNumber), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 if (decorator.CurrentRow.RowId == rowId)
                 {
-                    decorator.CurrentRow = RowObjectDecorator.Helper.SetFieldValue(decorator.CurrentRow, fieldNumber, fieldValue);
+                    decorator.CurrentRow.SetFieldValue(fieldNumber, fieldValue);
                     return decorator;
                 }
                 if (decorator.MultipleIteration)
@@ -189,7 +200,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     {
                         if (decorator.OtherRows[i].RowId == rowId)
                         {
-                            decorator.OtherRows[i] = RowObjectDecorator.Helper.SetFieldValue(decorator.OtherRows[i], fieldNumber, fieldValue);
+                            decorator.OtherRows[i].SetFieldValue(fieldNumber, fieldValue);
                             return decorator;
                         }
                     }

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015Decorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015Decorator.cs
@@ -66,6 +66,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         public void AddFormObject(string formId, bool multipleIteration) => Forms = Helper.AddFormObject(this, formId, multipleIteration).Forms;
 
         /// <summary>
+        /// Returns the CurrentRow RowId of the form matching the FormId.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <returns></returns>
+        public string GetCurrentRowId(string formId) => Helper.GetCurrentRowId(this, formId);
+
+        /// <summary>
         /// Returns the first value of the field matching the Field Number.
         /// </summary>
         /// <param name="fieldNumber"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2015DecoratorHelper.cs
@@ -9,7 +9,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
     public sealed partial class OptionObject2015Decorator
     {
-        public class Helper : DecoratorHelper
+        private sealed class Helper : DecoratorHelper
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
@@ -83,6 +83,23 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return AddFormObject(optionObject, formObject);
             }
             /// <summary>
+            /// Gets the CurrentRow.RowId of the <see cref="FormObject"/> in the <see cref="OptionObject2015Decorator"/> by FormId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static string GetCurrentRowId(OptionObject2015Decorator optionObject, string formId)
+            {
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                foreach (var formObject in optionObject.Forms)
+                {
+                    if (formObject.FormId == formId)
+                        return formObject.GetCurrentRowId();
+                }
+                throw new ArgumentException(resourceManager.GetString("noFormObjectsFoundByFormId", CultureInfo.CurrentCulture), nameof(optionObject));
+            }
+            /// <summary>
             /// Returns the FieldValue of a specified <see cref="FieldObject"/> in an <see cref="OptionObject2015Decorator"/> by FieldNumber.
             /// </summary>
             /// <param name="optionObject"></param>
@@ -97,7 +114,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.GetFieldValue(form, fieldNumber);
+                    return form.GetFieldValue(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -122,7 +139,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 foreach (var form in optionObject.Forms)
                 {
                     if (form.FormId == formId)
-                        return FormObjectDecorator.Helper.GetFieldValue(form, rowId, fieldNumber);
+                        return form.GetFieldValue(rowId, fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -140,10 +157,10 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 if (optionObject.Forms == null)
                     throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(OptionObjectMissingForms, CultureInfo.CurrentCulture));
-                foreach (var formObject in optionObject.Forms)
+                foreach (var form in optionObject.Forms)
                 {
-                    if (formObject.FormId == formId)
-                        return FormObjectDecorator.Helper.GetMultipleIterationStatus(formObject);
+                    if (form.FormId == formId)
+                        return form.GetMultipleIterationStatus();
                 }
                 throw new FormObjectNotFoundException(string.Format(resourceManager.GetString(NoFormObjectsFoundByFormId, CultureInfo.CurrentCulture), formId), formId);
             }
@@ -164,7 +181,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldEnabled(form, fieldNumber);
+                    return form.IsFieldEnabled(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -185,7 +202,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldLocked(form, fieldNumber);
+                    return form.IsFieldLocked(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -222,7 +239,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldRequired(form, fieldNumber);
+                    return form.IsFieldRequired(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -302,12 +319,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 for (int i = 0; i < decorator.Forms.Count; i++)
                 {
                     if (decorator.Forms[i].FormId == formId)
-                    {
-                        var formObject = FormObjectDecorator.Helper.SetFieldValue(decorator.Forms[i], rowId, fieldNumber, fieldValue);
-                        if (formObject.CurrentRow != null ||
-                            formObject.OtherRows.Count > 0)
-                            decorator.Forms[i] = formObject;
-                    }
+                        decorator.Forms[i].SetFieldValue(rowId, fieldNumber, fieldValue);
                 }
                 return decorator;
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2Decorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2Decorator.cs
@@ -65,6 +65,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         public void AddFormObject(string formId, bool multipleIteration) => Forms = Helper.AddFormObject(this, formId, multipleIteration).Forms;
 
         /// <summary>
+        /// Returns the CurrentRow RowId of the form matching the FormId.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <returns></returns>
+        public string GetCurrentRowId(string formId) => Helper.GetCurrentRowId(this, formId);
+
+        /// <summary>
         /// Returns the first value of the field matching the Field Number.
         /// </summary>
         /// <param name="fieldNumber"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObject2DecoratorHelper.cs
@@ -9,7 +9,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
     public sealed partial class OptionObject2Decorator
     {
-        public class Helper : DecoratorHelper
+        private sealed class Helper : DecoratorHelper
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
@@ -83,6 +83,23 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return AddFormObject(optionObject, formObject);
             }
             /// <summary>
+            /// Gets the CurrentRow.RowId of the <see cref="FormObject"/> in the <see cref="OptionObject2Decorator"/> by FormId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static string GetCurrentRowId(OptionObject2Decorator optionObject, string formId)
+            {
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                foreach (var formObject in optionObject.Forms)
+                {
+                    if (formObject.FormId == formId)
+                        return formObject.GetCurrentRowId();
+                }
+                throw new ArgumentException(resourceManager.GetString("noFormObjectsFoundByFormId", CultureInfo.CurrentCulture), nameof(optionObject));
+            }
+            /// <summary>
             /// Returns the FieldValue of a specified <see cref="FieldObject"/> in an <see cref="OptionObject2Decorator"/> by FieldNumber.
             /// </summary>
             /// <param name="optionObject"></param>
@@ -97,7 +114,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.GetFieldValue(form, fieldNumber);
+                    return form.GetFieldValue(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -122,7 +139,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 foreach (var form in optionObject.Forms)
                 {
                     if (form.FormId == formId)
-                        return FormObjectDecorator.Helper.GetFieldValue(form, rowId, fieldNumber);
+                        return form.GetFieldValue(rowId, fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -140,10 +157,10 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 if (optionObject.Forms == null)
                     throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(OptionObjectMissingForms, CultureInfo.CurrentCulture));
-                foreach (var formObject in optionObject.Forms)
+                foreach (var form in optionObject.Forms)
                 {
-                    if (formObject.FormId == formId)
-                        return FormObjectDecorator.Helper.GetMultipleIterationStatus(formObject);
+                    if (form.FormId == formId)
+                        return form.GetMultipleIterationStatus();
                 }
                 throw new FormObjectNotFoundException(string.Format(resourceManager.GetString(NoFormObjectsFoundByFormId, CultureInfo.CurrentCulture), formId), formId);
             }
@@ -164,7 +181,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldEnabled(form, fieldNumber);
+                    return form.IsFieldEnabled(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -185,7 +202,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldLocked(form, fieldNumber);
+                    return form.IsFieldLocked(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -222,7 +239,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldRequired(form, fieldNumber);
+                    return form.IsFieldRequired(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -302,12 +319,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 for (int i = 0; i < decorator.Forms.Count; i++)
                 {
                     if (decorator.Forms[i].FormId == formId)
-                    {
-                        var formObject = FormObjectDecorator.Helper.SetFieldValue(decorator.Forms[i], rowId, fieldNumber, fieldValue);
-                        if (formObject.CurrentRow != null ||
-                            formObject.OtherRows.Count > 0)
-                            decorator.Forms[i] = formObject;
-                    }
+                        decorator.Forms[i].SetFieldValue(rowId, fieldNumber, fieldValue);
                 }
                 return decorator;
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecorator.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecorator.cs
@@ -62,6 +62,13 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
         public void AddFormObject(string formId, bool multipleIteration) => Forms = Helper.AddFormObject(this, formId, multipleIteration).Forms;
 
         /// <summary>
+        /// Returns the CurrentRow RowId of the form matching the FormId.
+        /// </summary>
+        /// <param name="formId"></param>
+        /// <returns></returns>
+        public string GetCurrentRowId(string formId) => Helper.GetCurrentRowId(this, formId);
+
+        /// <summary>
         /// Returns the first value of the field matching the Field Number.
         /// </summary>
         /// <param name="fieldNumber"></param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/OptionObjectDecoratorHelper.cs
@@ -9,7 +9,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
     public sealed partial class OptionObjectDecorator
     {
-        public class Helper : DecoratorHelper
+        private sealed class Helper : DecoratorHelper
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 
@@ -83,6 +83,23 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 return AddFormObject(optionObject, formObject);
             }
             /// <summary>
+            /// Gets the CurrentRow.RowId of the <see cref="FormObject"/> in the <see cref="OptionObjectDecorator"/> by FormId.
+            /// </summary>
+            /// <param name="optionObject"></param>
+            /// <param name="formId"></param>
+            /// <returns></returns>
+            public static string GetCurrentRowId(OptionObjectDecorator optionObject, string formId)
+            {
+                if (string.IsNullOrEmpty(formId))
+                    throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+                foreach (var formObject in optionObject.Forms)
+                {
+                    if (formObject.FormId == formId)
+                        return formObject.GetCurrentRowId();
+                }
+                throw new ArgumentException(resourceManager.GetString("noFormObjectsFoundByFormId", CultureInfo.CurrentCulture), nameof(optionObject));
+            }
+            /// <summary>
             /// Returns the FieldValue of a specified <see cref="FieldObject"/> in an <see cref="OptionObjectDecorator"/> by FieldNumber.
             /// </summary>
             /// <param name="optionObject"></param>
@@ -97,7 +114,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.GetFieldValue(form, fieldNumber);
+                    return form.GetFieldValue(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -122,7 +139,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 foreach (var form in optionObject.Forms)
                 {
                     if (form.FormId == formId)
-                        return FormObjectDecorator.Helper.GetFieldValue(form, rowId, fieldNumber);
+                        return form.GetFieldValue(rowId, fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -140,10 +157,10 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                     throw new ArgumentNullException(nameof(formId), resourceManager.GetString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
                 if (optionObject.Forms == null)
                     throw new ArgumentNullException(nameof(optionObject), resourceManager.GetString(OptionObjectMissingForms, CultureInfo.CurrentCulture));
-                foreach (var formObject in optionObject.Forms)
+                foreach (var form in optionObject.Forms)
                 {
-                    if (formObject.FormId == formId)
-                        return FormObjectDecorator.Helper.GetMultipleIterationStatus(formObject);
+                    if (form.FormId == formId)
+                        return form.GetMultipleIterationStatus();
                 }
                 throw new FormObjectNotFoundException(string.Format(resourceManager.GetString(NoFormObjectsFoundByFormId, CultureInfo.CurrentCulture), formId), formId);
             }
@@ -164,7 +181,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldEnabled(form, fieldNumber);
+                    return form.IsFieldEnabled(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -185,7 +202,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldLocked(form, fieldNumber);
+                    return form.IsFieldLocked(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -222,7 +239,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 var form = optionObject.Forms.Find(x => x.IsFieldPresent(fieldNumber));
                 if (form != null)
                 {
-                    return FormObjectDecorator.Helper.IsFieldRequired(form, fieldNumber);
+                    return form.IsFieldRequired(fieldNumber);
                 }
                 throw new FieldObjectNotFoundException(string.Format(resourceManager.GetString(NoFieldObjectsFoundByFieldNumber, CultureInfo.CurrentCulture), fieldNumber), fieldNumber);
             }
@@ -302,12 +319,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
                 for (int i = 0; i < decorator.Forms.Count; i++)
                 {
                     if (decorator.Forms[i].FormId == formId)
-                    {
-                        var formObject = FormObjectDecorator.Helper.SetFieldValue(decorator.Forms[i], rowId, fieldNumber, fieldValue);
-                        if (formObject.CurrentRow != null ||
-                            formObject.OtherRows.Count > 0)
-                            decorator.Forms[i] = formObject;
-                    }
+                        decorator.Forms[i].SetFieldValue(rowId, fieldNumber, fieldValue);
                 }
                 return decorator;
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/RowObjectDecoratorHelper.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Net/Decorators/RowObjectDecoratorHelper.cs
@@ -9,7 +9,7 @@ namespace RarelySimple.AvatarScriptLink.Net.Decorators
 {
     public sealed partial class RowObjectDecorator
     {
-        public class Helper : DecoratorHelper
+        private sealed class Helper : DecoratorHelper
         {
             private static readonly ResourceManager resourceManager = new ResourceManager("RarelySimple.AvatarScriptLink.Net.Localizations", Assembly.GetExecutingAssembly());
 


### PR DESCRIPTION
This update implements the GetCurrentRowId method on the OptionObject and FormObject decorators.

In addition, this makes the object Helper classes private and sealed to help define expected usage patterns.