### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-sonarcloud.yml
+++ b/.github/workflows/docs-sonarcloud.yml
@@ -1,4 +1,6 @@
 name: SonarCloud Analysis (Docusaurus)
+permissions:
+  contents: read
 on:
 #   push:
 #     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/1](https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow involves checking out the repository and performing a SonarCloud scan, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
