### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-check-build.yml
+++ b/.github/workflows/docs-check-build.yml
@@ -1,4 +1,6 @@
 name: Build Documentation Site
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/2](https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level (root) to restrict the permissions of the `GITHUB_TOKEN`. Since the workflow only needs to read the repository contents (e.g., for checking out the code), we will set `contents: read` as the minimal required permission. This ensures that no unnecessary write permissions are granted.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
