### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-check-build.yml
+++ b/.github/workflows/dotnet-check-build.yml
@@ -1,4 +1,6 @@
 name: Build and Test .NET Package
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/3](https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the `contents` permission to `read`, which is sufficient for the current workflow steps. This ensures that the `GITHUB_TOKEN` has the minimum required permissions and prevents unintended write access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
