### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-check-sonarcloud.yml
+++ b/.github/workflows/dotnet-check-sonarcloud.yml
@@ -1,4 +1,7 @@
 name: SonarCloud Analysis (.NET)
+permissions:
+  contents: read
+  pull-requests: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/4](https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Based on the workflow's operations, it primarily needs `contents: read` to fetch repository contents and `pull-requests: read` to access pull request information. These permissions will be sufficient for the workflow's tasks while adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
