### PR TITLE
Add support for Required and Optional fields in OptionObject and RowO…

### DIFF
--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
@@ -65,6 +65,172 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.ThrowsException<ArgumentException>(act);
         }
 
+        [DataTestMethod]
+        [DataRow("Disabled")]
+        [DataRow("Enabled")]
+        [DataRow("Locked")]
+        [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
+        public void SetField_FormObject_WithFieldOnlyInOtherRow_OnlyAppliesToMatchingRow(string operation)
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1", RowAction = string.Empty }, MultipleIteration = true };
+            var otherRow = new RowObject { RowId = "2", RowAction = string.Empty };
+
+            switch (operation)
+            {
+                case "Disabled":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Enabled = "1" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Enabled = "1" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetDisabledField("100");
+
+                    Assert.AreEqual("1", form.CurrentRow.Fields[0].Enabled);
+                    Assert.AreEqual("0", otherRow.Fields[0].Enabled);
+                    break;
+                case "Enabled":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Enabled = "0" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Enabled = "0" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetEnabledField("100");
+
+                    Assert.AreEqual("0", form.CurrentRow.Fields[0].Enabled);
+                    Assert.AreEqual("1", otherRow.Fields[0].Enabled);
+                    break;
+                case "Locked":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Lock = "0" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Lock = "0" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetLockedField("100");
+
+                    Assert.AreEqual("0", form.CurrentRow.Fields[0].Lock);
+                    Assert.AreEqual("1", otherRow.Fields[0].Lock);
+                    break;
+                case "Unlocked":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Lock = "1" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Lock = "1" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetUnlockedField("100");
+
+                    Assert.AreEqual("1", form.CurrentRow.Fields[0].Lock);
+                    Assert.AreEqual("0", otherRow.Fields[0].Lock);
+                    break;
+                case "Required":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetRequiredField("100");
+
+                    Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("1", otherRow.Fields[0].Required);
+                    break;
+                case "Optional":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetOptionalField("100");
+
+                    Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("0", otherRow.Fields[0].Required);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(operation));
+            }
+
+            Assert.AreEqual(string.Empty, form.CurrentRow.RowAction);
+            Assert.AreEqual(RowObject.RowActions.Edit, otherRow.RowAction);
+        }
+
+        [DataTestMethod]
+        [DataRow("Disabled")]
+        [DataRow("Enabled")]
+        [DataRow("Locked")]
+        [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
+        public void SetFields_FormObject_WithMixedRowMatches_OnlyAppliesToMatchingRows(string operation)
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1", RowAction = string.Empty }, MultipleIteration = true };
+            var otherRow = new RowObject { RowId = "2", RowAction = string.Empty };
+
+            switch (operation)
+            {
+                case "Disabled":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Enabled = "1" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "200", Enabled = "1" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetDisabledFields(["100"]);
+
+                    Assert.AreEqual("0", form.CurrentRow.Fields[0].Enabled);
+                    Assert.AreEqual("1", otherRow.Fields[0].Enabled);
+                    break;
+                case "Enabled":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Enabled = "0" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "200", Enabled = "0" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetEnabledFields(["100"]);
+
+                    Assert.AreEqual("1", form.CurrentRow.Fields[0].Enabled);
+                    Assert.AreEqual("0", otherRow.Fields[0].Enabled);
+                    break;
+                case "Locked":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Lock = "0" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "200", Lock = "0" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetLockedFields(["100"]);
+
+                    Assert.AreEqual("1", form.CurrentRow.Fields[0].Lock);
+                    Assert.AreEqual("0", otherRow.Fields[0].Lock);
+                    break;
+                case "Unlocked":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Lock = "1" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "200", Lock = "1" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetUnlockedFields(["100"]);
+
+                    Assert.AreEqual("0", form.CurrentRow.Fields[0].Lock);
+                    Assert.AreEqual("1", otherRow.Fields[0].Lock);
+                    break;
+                case "Required":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetRequiredFields(["100"]);
+
+                    Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("0", otherRow.Fields[0].Required);
+                    break;
+                case "Optional":
+                    form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+                    otherRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+                    form.OtherRows.Add(otherRow);
+
+                    form.SetOptionalFields(["100"]);
+
+                    Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("1", otherRow.Fields[0].Required);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(operation));
+            }
+
+            Assert.AreEqual(RowObject.RowActions.Edit, form.CurrentRow.RowAction);
+            Assert.AreEqual(string.Empty, otherRow.RowAction);
+        }
+
         [TestMethod]
         public void GetFormId_FormObject_ReturnsFormId()
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
@@ -495,6 +495,72 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void SetRequiredFields_FormObject_WithMultipleIteration_SetsMatchingFieldsInAllRows()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1" }, MultipleIteration = true };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "101", Required = "0" });
+
+            var otherRow = new RowObject { RowId = "2" };
+            otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            otherRow.Fields.Add(new FieldObject { FieldNumber = "101", Required = "0" });
+            form.OtherRows.Add(otherRow);
+
+            // Act
+            form.SetRequiredFields(["101"]);
+
+            // Assert
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+            Assert.AreEqual("1", form.CurrentRow.Fields[1].Required);
+            Assert.AreEqual("0", otherRow.Fields[0].Required);
+            Assert.AreEqual("1", otherRow.Fields[1].Required);
+        }
+
+        [TestMethod]
+        public void SetRequiredFields_FormObject_WithNoMatchingFields_ThrowsArgumentException()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => form.SetRequiredFields(["100"]));
+        }
+
+        [TestMethod]
+        public void SetRequiredFields_FormObject_WithNullCurrentRow_ReturnsOriginalForm()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = null! };
+
+            // Act
+            var result = form.SetRequiredFields(["100"]);
+
+            // Assert
+            Assert.AreSame(form, result);
+        }
+
+        [TestMethod]
+        public void SetRequiredFields_FormObject_WithMultipleIterationFalse_DoesNotModifyOtherRows()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1" }, MultipleIteration = false };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+
+            var otherRow = new RowObject { RowId = "2" };
+            otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            form.OtherRows.Add(otherRow);
+
+            // Act
+            form.SetRequiredFields(["100"]);
+
+            // Assert
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+            Assert.AreEqual("0", otherRow.Fields[0].Required);
+        }
+
+        [TestMethod]
         public void SetOptionalFields_FormObject_WithMultipleIteration_SetsMatchingFieldsOptionalInAllRows()
         {
             // Arrange
@@ -514,6 +580,26 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.AreEqual("0", form.CurrentRow.Fields[1].Required);
             Assert.AreEqual("1", otherRow.Fields[0].Required);
             Assert.AreEqual("0", otherRow.Fields[1].Required);
+        }
+
+        [TestMethod]
+        public void SetOptionalField_FormObject_WithMultipleIteration_SetsOptionalInAllRows()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1", RowAction = string.Empty }, MultipleIteration = true };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            var otherRow = new RowObject { RowId = "2", RowAction = string.Empty };
+            otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            form.OtherRows.Add(otherRow);
+
+            // Act
+            form.SetOptionalField("100");
+
+            // Assert
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+            Assert.AreEqual("0", otherRow.Fields[0].Required);
+            Assert.AreEqual(RowObject.RowActions.Edit, form.CurrentRow.RowAction);
+            Assert.AreEqual(RowObject.RowActions.Edit, otherRow.RowAction);
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_FormObject_WithNullFieldNumber_ThrowsArgumentNullException(string operation)
         {
             // Arrange
@@ -25,6 +27,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => form.SetEnabledField(null!),
                 "Locked" => () => form.SetLockedField(null!),
                 "Unlocked" => () => form.SetUnlockedField(null!),
+                "Required" => () => form.SetRequiredField(null!),
+                "Optional" => () => form.SetOptionalField(null!),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -37,6 +41,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_FormObject_WithEmptyFieldNumber_ThrowsArgumentException(string operation)
         {
             // Arrange
@@ -50,6 +56,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => form.SetEnabledField(string.Empty),
                 "Locked" => () => form.SetLockedField(string.Empty),
                 "Unlocked" => () => form.SetUnlockedField(string.Empty),
+                "Required" => () => form.SetRequiredField(string.Empty),
+                "Optional" => () => form.SetOptionalField(string.Empty),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -464,6 +472,48 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.AreEqual("0", form.CurrentRow.Fields[1].Lock);
             Assert.AreEqual("1", otherRow.Fields[0].Lock);
             Assert.AreEqual("0", otherRow.Fields[1].Lock);
+        }
+
+        [TestMethod]
+        public void SetRequiredField_FormObject_WithMultipleIteration_SetsFieldRequiredInAllRows()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1", RowAction = string.Empty }, MultipleIteration = true };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            var otherRow = new RowObject { RowId = "2", RowAction = string.Empty };
+            otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            form.OtherRows.Add(otherRow);
+
+            // Act
+            form.SetRequiredField("100");
+
+            // Assert
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+            Assert.AreEqual("1", otherRow.Fields[0].Required);
+            Assert.AreEqual(RowObject.RowActions.Edit, form.CurrentRow.RowAction);
+            Assert.AreEqual(RowObject.RowActions.Edit, otherRow.RowAction);
+        }
+
+        [TestMethod]
+        public void SetOptionalFields_FormObject_WithMultipleIteration_SetsMatchingFieldsOptionalInAllRows()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "1" }, MultipleIteration = true };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "101", Required = "1" });
+            var otherRow = new RowObject { RowId = "2" };
+            otherRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            otherRow.Fields.Add(new FieldObject { FieldNumber = "101", Required = "1" });
+            form.OtherRows.Add(otherRow);
+
+            // Act
+            form.SetOptionalFields(["101"]);
+
+            // Assert
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+            Assert.AreEqual("0", form.CurrentRow.Fields[1].Required);
+            Assert.AreEqual("1", otherRow.Fields[0].Required);
+            Assert.AreEqual("0", otherRow.Fields[1].Required);
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_OptionObject_WithNullFieldNumber_ThrowsArgumentNullException(string operation)
         {
             var optionObject = new OptionObject();
@@ -24,6 +26,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => optionObject.SetEnabledField(null!),
                 "Locked" => () => optionObject.SetLockedField(null!),
                 "Unlocked" => () => optionObject.SetUnlockedField(null!),
+                "Required" => () => optionObject.SetRequiredField(null!),
+                "Optional" => () => optionObject.SetOptionalField(null!),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -35,6 +39,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_OptionObject_WithEmptyFieldNumber_ThrowsArgumentException(string operation)
         {
             var optionObject = new OptionObject();
@@ -48,6 +54,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => optionObject.SetEnabledField(string.Empty),
                 "Locked" => () => optionObject.SetLockedField(string.Empty),
                 "Unlocked" => () => optionObject.SetUnlockedField(string.Empty),
+                "Required" => () => optionObject.SetRequiredField(string.Empty),
+                "Optional" => () => optionObject.SetOptionalField(string.Empty),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -59,6 +67,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetFields_OptionObject_WithMixedFormMatches_OnlyAppliesToMatchingForms(string operation)
         {
             var optionObject = new OptionObject();
@@ -110,6 +120,28 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
 
                     Assert.AreEqual("0", matchingForm.CurrentRow.Fields[0].Lock);
                     Assert.AreEqual("1", nonMatchingForm.CurrentRow.Fields[0].Lock);
+                    break;
+                case "Required":
+                    matchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+                    nonMatchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+                    optionObject.Forms.Add(matchingForm);
+                    optionObject.Forms.Add(nonMatchingForm);
+
+                    optionObject.SetRequiredFields(new List<string> { "100" });
+
+                    Assert.AreEqual("1", matchingForm.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("0", nonMatchingForm.CurrentRow.Fields[0].Required);
+                    break;
+                case "Optional":
+                    matchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+                    nonMatchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+                    optionObject.Forms.Add(matchingForm);
+                    optionObject.Forms.Add(nonMatchingForm);
+
+                    optionObject.SetOptionalFields(new List<string> { "100" });
+
+                    Assert.AreEqual("0", matchingForm.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("1", nonMatchingForm.CurrentRow.Fields[0].Required);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operation));
@@ -512,6 +544,28 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             optionObject.Forms.Add(form);
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.SetUnlockedField("100"));
+        }
+
+        [TestMethod]
+        public void SetRequiredField_OptionObject_WithNoMatchingField_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.SetRequiredField("100"));
+        }
+
+        [TestMethod]
+        public void SetOptionalField_OptionObject_WithNoMatchingField_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.SetOptionalField("100"));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
@@ -569,6 +569,58 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void SetRequiredField_OptionObject_WithMatchingField_SetsRequired()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetRequiredField("100");
+
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetOptionalField_OptionObject_WithMatchingField_SetsOptional()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetOptionalField("100");
+
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetRequiredFields_OptionObject_WithFieldObjects_SetsRequired()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetRequiredFields(new List<FieldObject> { new FieldObject { FieldNumber = "100" } });
+
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetOptionalFields_OptionObject_WithFieldObjects_SetsOptional()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetOptionalFields(new List<FieldObject> { new FieldObject { FieldNumber = "100" } });
+
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
         public void SetLockedFields_OptionObject_WithDuplicateFieldNumbers_LocksTargetField()
         {
             var optionObject = new OptionObject();

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
@@ -594,6 +594,43 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
         }
 
+        [DataTestMethod]
+        [DataRow("Required", "0", "0", "1", "0")]
+        [DataRow("Optional", "1", "1", "0", "1")]
+        public void SetSingleRequiredOptionalField_OptionObject_WithMixedFormMatches_OnlyMutatesMatchingForm(
+            string operation,
+            string initialTarget,
+            string initialNonTarget,
+            string expectedTarget,
+            string expectedNonTarget)
+        {
+            var optionObject = new OptionObject();
+            var targetForm = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            targetForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = initialTarget });
+
+            var nonTargetForm = new FormObject { FormId = "2", CurrentRow = new RowObject { RowId = "1" } };
+            nonTargetForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = initialNonTarget });
+
+            optionObject.Forms.Add(targetForm);
+            optionObject.Forms.Add(nonTargetForm);
+
+            switch (operation)
+            {
+                case "Required":
+                    optionObject.SetRequiredField("100");
+                    break;
+                case "Optional":
+                    optionObject.SetOptionalField("100");
+                    break;
+                default:
+                    Assert.Fail($"Unsupported operation '{operation}'");
+                    break;
+            }
+
+            Assert.AreEqual(expectedTarget, targetForm.CurrentRow.Fields[0].Required);
+            Assert.AreEqual(expectedNonTarget, nonTargetForm.CurrentRow.Fields[0].Required);
+        }
+
         [TestMethod]
         public void SetRequiredFields_OptionObject_WithFieldObjects_SetsRequired()
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
@@ -414,5 +414,57 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.SetOptionalField("100"));
         }
+
+        [TestMethod]
+        public void SetRequiredField_OptionObject2_WithMatchingField_SetsRequired()
+        {
+            var optionObject = new OptionObject2();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetRequiredField("100");
+
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetOptionalField_OptionObject2_WithMatchingField_SetsOptional()
+        {
+            var optionObject = new OptionObject2();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetOptionalField("100");
+
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetRequiredFields_OptionObject2_WithFieldObjects_SetsRequired()
+        {
+            var optionObject = new OptionObject2();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetRequiredFields(new List<FieldObject> { new FieldObject { FieldNumber = "100" } });
+
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetOptionalFields_OptionObject2_WithFieldObjects_SetsOptional()
+        {
+            var optionObject = new OptionObject2();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetOptionalFields(new List<FieldObject> { new FieldObject { FieldNumber = "100" } });
+
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_OptionObject2_WithNullFieldNumber_ThrowsArgumentNullException(string operation)
         {
             var optionObject = new OptionObject2();
@@ -24,6 +26,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => optionObject.SetEnabledField(null!),
                 "Locked" => () => optionObject.SetLockedField(null!),
                 "Unlocked" => () => optionObject.SetUnlockedField(null!),
+                "Required" => () => optionObject.SetRequiredField(null!),
+                "Optional" => () => optionObject.SetOptionalField(null!),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -35,6 +39,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_OptionObject2_WithEmptyFieldNumber_ThrowsArgumentException(string operation)
         {
             var optionObject = new OptionObject2();
@@ -48,6 +54,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => optionObject.SetEnabledField(string.Empty),
                 "Locked" => () => optionObject.SetLockedField(string.Empty),
                 "Unlocked" => () => optionObject.SetUnlockedField(string.Empty),
+                "Required" => () => optionObject.SetRequiredField(string.Empty),
+                "Optional" => () => optionObject.SetOptionalField(string.Empty),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -59,6 +67,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetFields_OptionObject2_WithMixedFormMatches_OnlyAppliesToMatchingForms(string operation)
         {
             var optionObject = new OptionObject2();
@@ -110,6 +120,28 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
 
                     Assert.AreEqual("0", matchingForm.CurrentRow.Fields[0].Lock);
                     Assert.AreEqual("1", nonMatchingForm.CurrentRow.Fields[0].Lock);
+                    break;
+                case "Required":
+                    matchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+                    nonMatchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+                    optionObject.Forms.Add(matchingForm);
+                    optionObject.Forms.Add(nonMatchingForm);
+
+                    optionObject.SetRequiredFields(new List<string> { "100" });
+
+                    Assert.AreEqual("1", matchingForm.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("0", nonMatchingForm.CurrentRow.Fields[0].Required);
+                    break;
+                case "Optional":
+                    matchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+                    nonMatchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+                    optionObject.Forms.Add(matchingForm);
+                    optionObject.Forms.Add(nonMatchingForm);
+
+                    optionObject.SetOptionalFields(new List<string> { "100" });
+
+                    Assert.AreEqual("0", matchingForm.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("1", nonMatchingForm.CurrentRow.Fields[0].Required);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operation));
@@ -359,6 +391,28 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             optionObject.Forms.Add(form);
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.SetLockedField("100"));
+        }
+
+        [TestMethod]
+        public void SetRequiredField_OptionObject2_WithNoMatchingField_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.SetRequiredField("100"));
+        }
+
+        [TestMethod]
+        public void SetOptionalField_OptionObject2_WithNoMatchingField_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.SetOptionalField("100"));
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
@@ -441,6 +441,43 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
         }
 
+        [DataTestMethod]
+        [DataRow("Required", "0", "0", "1", "0")]
+        [DataRow("Optional", "1", "1", "0", "1")]
+        public void SetSingleRequiredOptionalField_OptionObject2_WithMixedFormMatches_OnlyMutatesMatchingForm(
+            string operation,
+            string initialTarget,
+            string initialNonTarget,
+            string expectedTarget,
+            string expectedNonTarget)
+        {
+            var optionObject = new OptionObject2();
+            var targetForm = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            targetForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = initialTarget });
+
+            var nonTargetForm = new FormObject { FormId = "2", CurrentRow = new RowObject { RowId = "1" } };
+            nonTargetForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = initialNonTarget });
+
+            optionObject.Forms.Add(targetForm);
+            optionObject.Forms.Add(nonTargetForm);
+
+            switch (operation)
+            {
+                case "Required":
+                    optionObject.SetRequiredField("100");
+                    break;
+                case "Optional":
+                    optionObject.SetOptionalField("100");
+                    break;
+                default:
+                    Assert.Fail($"Unsupported operation '{operation}'");
+                    break;
+            }
+
+            Assert.AreEqual(expectedTarget, targetForm.CurrentRow.Fields[0].Required);
+            Assert.AreEqual(expectedNonTarget, nonTargetForm.CurrentRow.Fields[0].Required);
+        }
+
         [TestMethod]
         public void SetRequiredFields_OptionObject2_WithFieldObjects_SetsRequired()
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
@@ -487,6 +487,43 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
         }
 
+        [DataTestMethod]
+        [DataRow("Required", "0", "0", "1", "0")]
+        [DataRow("Optional", "1", "1", "0", "1")]
+        public void SetSingleRequiredOptionalField_OptionObject2015_WithMixedFormMatches_OnlyMutatesMatchingForm(
+            string operation,
+            string initialTarget,
+            string initialNonTarget,
+            string expectedTarget,
+            string expectedNonTarget)
+        {
+            var optionObject = new OptionObject2015();
+            var targetForm = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            targetForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = initialTarget });
+
+            var nonTargetForm = new FormObject { FormId = "2", CurrentRow = new RowObject { RowId = "1" } };
+            nonTargetForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = initialNonTarget });
+
+            optionObject.Forms.Add(targetForm);
+            optionObject.Forms.Add(nonTargetForm);
+
+            switch (operation)
+            {
+                case "Required":
+                    optionObject.SetRequiredField("100");
+                    break;
+                case "Optional":
+                    optionObject.SetOptionalField("100");
+                    break;
+                default:
+                    Assert.Fail($"Unsupported operation '{operation}'");
+                    break;
+            }
+
+            Assert.AreEqual(expectedTarget, targetForm.CurrentRow.Fields[0].Required);
+            Assert.AreEqual(expectedNonTarget, nonTargetForm.CurrentRow.Fields[0].Required);
+        }
+
         [TestMethod]
         public void SetRequiredFields_OptionObject2015_WithFieldObjects_SetsRequired()
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
@@ -460,5 +460,57 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.SetOptionalField("100"));
         }
+
+        [TestMethod]
+        public void SetRequiredField_OptionObject2015_WithMatchingField_SetsRequired()
+        {
+            var optionObject = new OptionObject2015();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetRequiredField("100");
+
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetOptionalField_OptionObject2015_WithMatchingField_SetsOptional()
+        {
+            var optionObject = new OptionObject2015();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetOptionalField("100");
+
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetRequiredFields_OptionObject2015_WithFieldObjects_SetsRequired()
+        {
+            var optionObject = new OptionObject2015();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetRequiredFields(new List<FieldObject> { new FieldObject { FieldNumber = "100" } });
+
+            Assert.AreEqual("1", form.CurrentRow.Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void SetOptionalFields_OptionObject2015_WithFieldObjects_SetsOptional()
+        {
+            var optionObject = new OptionObject2015();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            optionObject.SetOptionalFields(new List<FieldObject> { new FieldObject { FieldNumber = "100" } });
+
+            Assert.AreEqual("0", form.CurrentRow.Fields[0].Required);
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_OptionObject2015_WithNullFieldNumber_ThrowsArgumentNullException(string operation)
         {
             var optionObject = new OptionObject2015();
@@ -24,6 +26,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => optionObject.SetEnabledField(null!),
                 "Locked" => () => optionObject.SetLockedField(null!),
                 "Unlocked" => () => optionObject.SetUnlockedField(null!),
+                "Required" => () => optionObject.SetRequiredField(null!),
+                "Optional" => () => optionObject.SetOptionalField(null!),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -35,6 +39,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_OptionObject2015_WithEmptyFieldNumber_ThrowsArgumentException(string operation)
         {
             var optionObject = new OptionObject2015();
@@ -48,6 +54,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => optionObject.SetEnabledField(string.Empty),
                 "Locked" => () => optionObject.SetLockedField(string.Empty),
                 "Unlocked" => () => optionObject.SetUnlockedField(string.Empty),
+                "Required" => () => optionObject.SetRequiredField(string.Empty),
+                "Optional" => () => optionObject.SetOptionalField(string.Empty),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -59,6 +67,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetFields_OptionObject2015_WithMixedFormMatches_OnlyAppliesToMatchingForms(string operation)
         {
             var optionObject = new OptionObject2015();
@@ -110,6 +120,28 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
 
                     Assert.AreEqual("0", matchingForm.CurrentRow.Fields[0].Lock);
                     Assert.AreEqual("1", nonMatchingForm.CurrentRow.Fields[0].Lock);
+                    break;
+                case "Required":
+                    matchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+                    nonMatchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+                    optionObject.Forms.Add(matchingForm);
+                    optionObject.Forms.Add(nonMatchingForm);
+
+                    optionObject.SetRequiredFields(new List<string> { "100" });
+
+                    Assert.AreEqual("1", matchingForm.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("0", nonMatchingForm.CurrentRow.Fields[0].Required);
+                    break;
+                case "Optional":
+                    matchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+                    nonMatchingForm.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+                    optionObject.Forms.Add(matchingForm);
+                    optionObject.Forms.Add(nonMatchingForm);
+
+                    optionObject.SetOptionalFields(new List<string> { "100" });
+
+                    Assert.AreEqual("0", matchingForm.CurrentRow.Fields[0].Required);
+                    Assert.AreEqual("1", nonMatchingForm.CurrentRow.Fields[0].Required);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operation));
@@ -405,6 +437,28 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             optionObject.Forms.Add(form);
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.SetUnlockedField("100"));
+        }
+
+        [TestMethod]
+        public void SetRequiredField_OptionObject2015_WithNoMatchingField_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2015();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "0" });
+            optionObject.Forms.Add(form);
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.SetRequiredField("100"));
+        }
+
+        [TestMethod]
+        public void SetOptionalField_OptionObject2015_WithNoMatchingField_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2015();
+            var form = new FormObject { FormId = "1", CurrentRow = new RowObject { RowId = "1" } };
+            form.CurrentRow.Fields.Add(new FieldObject { FieldNumber = "200", Required = "1" });
+            optionObject.Forms.Add(form);
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.SetOptionalField("100"));
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/RowObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/RowObjectHelpersTests.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_RowObject_WithNullFieldNumber_ThrowsArgumentNullException(string operation)
         {
             // Arrange
@@ -25,6 +27,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => row.SetEnabledField(null!),
                 "Locked" => () => row.SetLockedField(null!),
                 "Unlocked" => () => row.SetUnlockedField(null!),
+                "Required" => () => row.SetRequiredField(null!),
+                "Optional" => () => row.SetOptionalField(null!),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -37,6 +41,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         [DataRow("Enabled")]
         [DataRow("Locked")]
         [DataRow("Unlocked")]
+        [DataRow("Required")]
+        [DataRow("Optional")]
         public void SetField_RowObject_WithEmptyFieldNumber_ThrowsArgumentException(string operation)
         {
             // Arrange
@@ -50,6 +56,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 "Enabled" => () => row.SetEnabledField(string.Empty),
                 "Locked" => () => row.SetLockedField(string.Empty),
                 "Unlocked" => () => row.SetUnlockedField(string.Empty),
+                "Required" => () => row.SetRequiredField(string.Empty),
+                "Optional" => () => row.SetOptionalField(string.Empty),
                 _ => throw new ArgumentOutOfRangeException(nameof(operation))
             };
 
@@ -506,6 +514,37 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             // Assert
             Assert.AreEqual("0", row.Fields[0].Enabled);
             Assert.AreEqual("1", row.Fields[1].Enabled);
+        }
+
+        [TestMethod]
+        public void SetRequiredField_RowObject_WithExistingField_SetsRequiredAndRowAction()
+        {
+            // Arrange
+            var row = new RowObject { RowAction = string.Empty };
+            row.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+
+            // Act
+            row.SetRequiredField("100");
+
+            // Assert
+            Assert.AreEqual("1", row.Fields[0].Required);
+            Assert.AreEqual(RowObject.RowActions.Edit, row.RowAction);
+        }
+
+        [TestMethod]
+        public void SetOptionalFields_RowObject_WithFieldNumbers_SetsMatchingFieldsOptional()
+        {
+            // Arrange
+            var row = new RowObject();
+            row.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+            row.Fields.Add(new FieldObject { FieldNumber = "101", Required = "1" });
+
+            // Act
+            row.SetOptionalFields(["101"]);
+
+            // Assert
+            Assert.AreEqual("1", row.Fields[0].Required);
+            Assert.AreEqual("0", row.Fields[1].Required);
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/RowObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/RowObjectHelpersTests.cs
@@ -531,6 +531,42 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.AreEqual(RowObject.RowActions.Edit, row.RowAction);
         }
 
+        [DataTestMethod]
+        [DataRow("", RowObject.RowActions.Edit)]
+        [DataRow(RowObject.RowActions.Add, RowObject.RowActions.Add)]
+        [DataRow(RowObject.RowActions.Delete, RowObject.RowActions.Delete)]
+        [DataRow(RowObject.RowActions.Edit, RowObject.RowActions.Edit)]
+        public void SetRequiredField_RowObject_WithDifferentInitialRowActions_AppliesExpectedRowAction(
+            string initialRowAction,
+            string expectedRowAction)
+        {
+            // Arrange
+            var row = new RowObject { RowAction = initialRowAction };
+            row.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+
+            // Act
+            row.SetRequiredField("100");
+
+            // Assert
+            Assert.AreEqual("1", row.Fields[0].Required);
+            Assert.AreEqual(expectedRowAction, row.RowAction);
+        }
+
+        [TestMethod]
+        public void SetRequiredField_RowObject_WhenAlreadyRequired_DoesNotSetRowAction()
+        {
+            // Arrange
+            var row = new RowObject { RowAction = "" };
+            row.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+
+            // Act
+            row.SetRequiredField("100");
+
+            // Assert
+            Assert.AreEqual("1", row.Fields[0].Required);
+            Assert.AreEqual("", row.RowAction);
+        }
+
         [TestMethod]
         public void SetOptionalFields_RowObject_WithFieldNumbers_SetsMatchingFieldsOptional()
         {
@@ -560,6 +596,42 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             // Assert
             Assert.AreEqual("0", row.Fields[0].Required);
             Assert.AreEqual(RowObject.RowActions.Edit, row.RowAction);
+        }
+
+        [DataTestMethod]
+        [DataRow("", RowObject.RowActions.Edit)]
+        [DataRow(RowObject.RowActions.Add, RowObject.RowActions.Add)]
+        [DataRow(RowObject.RowActions.Delete, RowObject.RowActions.Delete)]
+        [DataRow(RowObject.RowActions.Edit, RowObject.RowActions.Edit)]
+        public void SetOptionalField_RowObject_WithDifferentInitialRowActions_AppliesExpectedRowAction(
+            string initialRowAction,
+            string expectedRowAction)
+        {
+            // Arrange
+            var row = new RowObject { RowAction = initialRowAction };
+            row.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+
+            // Act
+            row.SetOptionalField("100");
+
+            // Assert
+            Assert.AreEqual("0", row.Fields[0].Required);
+            Assert.AreEqual(expectedRowAction, row.RowAction);
+        }
+
+        [TestMethod]
+        public void SetOptionalField_RowObject_WhenAlreadyOptional_DoesNotSetRowAction()
+        {
+            // Arrange
+            var row = new RowObject { RowAction = "" };
+            row.Fields.Add(new FieldObject { FieldNumber = "100", Required = "0" });
+
+            // Act
+            row.SetOptionalField("100");
+
+            // Assert
+            Assert.AreEqual("0", row.Fields[0].Required);
+            Assert.AreEqual("", row.RowAction);
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/RowObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/RowObjectHelpersTests.cs
@@ -548,6 +548,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void SetOptionalField_RowObject_WithExistingRequiredField_SetsOptionalAndRowAction()
+        {
+            // Arrange
+            var row = new RowObject { RowAction = string.Empty };
+            row.Fields.Add(new FieldObject { FieldNumber = "100", Required = "1" });
+
+            // Act
+            row.SetOptionalField("100");
+
+            // Assert
+            Assert.AreEqual("0", row.Fields[0].Required);
+            Assert.AreEqual(RowObject.RowActions.Edit, row.RowAction);
+        }
+
+        [TestMethod]
         public void SetEnabledFields_RowObject_WithDeleteRowAction_PreservesDelete()
         {
             // Arrange

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -329,13 +329,19 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasFieldInForm)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
 
-            formObject.CurrentRow.SetDisabledField(fieldNumber);
+            if (formObject.CurrentRow.IsFieldPresent(fieldNumber))
+            {
+                formObject.CurrentRow.SetDisabledField(fieldNumber);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetDisabledField(fieldNumber);
+                    if (row.IsFieldPresent(fieldNumber))
+                    {
+                        row.SetDisabledField(fieldNumber);
+                    }
                 }
             }
 
@@ -361,13 +367,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasAnyField)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
 
-            formObject.CurrentRow.SetDisabledFields(fieldsToSet);
+            var currentRowFieldNumbers = fieldsToSet.Where(formObject.CurrentRow.IsFieldPresent).ToList();
+            if (currentRowFieldNumbers.Count > 0)
+            {
+                formObject.CurrentRow.SetDisabledFields(currentRowFieldNumbers);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetDisabledFields(fieldsToSet);
+                    var rowFieldNumbers = fieldsToSet.Where(row.IsFieldPresent).ToList();
+                    if (rowFieldNumbers.Count > 0)
+                    {
+                        row.SetDisabledFields(rowFieldNumbers);
+                    }
                 }
             }
 
@@ -393,13 +407,19 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasFieldInForm)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
 
-            formObject.CurrentRow.SetEnabledField(fieldNumber);
+            if (formObject.CurrentRow.IsFieldPresent(fieldNumber))
+            {
+                formObject.CurrentRow.SetEnabledField(fieldNumber);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetEnabledField(fieldNumber);
+                    if (row.IsFieldPresent(fieldNumber))
+                    {
+                        row.SetEnabledField(fieldNumber);
+                    }
                 }
             }
 
@@ -425,13 +445,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasAnyField)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
 
-            formObject.CurrentRow.SetEnabledFields(fieldsToSet);
+            var currentRowFieldNumbers = fieldsToSet.Where(formObject.CurrentRow.IsFieldPresent).ToList();
+            if (currentRowFieldNumbers.Count > 0)
+            {
+                formObject.CurrentRow.SetEnabledFields(currentRowFieldNumbers);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetEnabledFields(fieldsToSet);
+                    var rowFieldNumbers = fieldsToSet.Where(row.IsFieldPresent).ToList();
+                    if (rowFieldNumbers.Count > 0)
+                    {
+                        row.SetEnabledFields(rowFieldNumbers);
+                    }
                 }
             }
 
@@ -457,13 +485,19 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasFieldInForm)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
 
-            formObject.CurrentRow.SetLockedField(fieldNumber);
+            if (formObject.CurrentRow.IsFieldPresent(fieldNumber))
+            {
+                formObject.CurrentRow.SetLockedField(fieldNumber);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetLockedField(fieldNumber);
+                    if (row.IsFieldPresent(fieldNumber))
+                    {
+                        row.SetLockedField(fieldNumber);
+                    }
                 }
             }
 
@@ -489,13 +523,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasAnyField)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
 
-            formObject.CurrentRow.SetLockedFields(fieldsToSet);
+            var currentRowFieldNumbers = fieldsToSet.Where(formObject.CurrentRow.IsFieldPresent).ToList();
+            if (currentRowFieldNumbers.Count > 0)
+            {
+                formObject.CurrentRow.SetLockedFields(currentRowFieldNumbers);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetLockedFields(fieldsToSet);
+                    var rowFieldNumbers = fieldsToSet.Where(row.IsFieldPresent).ToList();
+                    if (rowFieldNumbers.Count > 0)
+                    {
+                        row.SetLockedFields(rowFieldNumbers);
+                    }
                 }
             }
 
@@ -521,13 +563,19 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasFieldInForm)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
 
-            formObject.CurrentRow.SetUnlockedField(fieldNumber);
+            if (formObject.CurrentRow.IsFieldPresent(fieldNumber))
+            {
+                formObject.CurrentRow.SetUnlockedField(fieldNumber);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetUnlockedField(fieldNumber);
+                    if (row.IsFieldPresent(fieldNumber))
+                    {
+                        row.SetUnlockedField(fieldNumber);
+                    }
                 }
             }
 
@@ -553,13 +601,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasAnyField)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
 
-            formObject.CurrentRow.SetUnlockedFields(fieldsToSet);
+            var currentRowFieldNumbers = fieldsToSet.Where(formObject.CurrentRow.IsFieldPresent).ToList();
+            if (currentRowFieldNumbers.Count > 0)
+            {
+                formObject.CurrentRow.SetUnlockedFields(currentRowFieldNumbers);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetUnlockedFields(fieldsToSet);
+                    var rowFieldNumbers = fieldsToSet.Where(row.IsFieldPresent).ToList();
+                    if (rowFieldNumbers.Count > 0)
+                    {
+                        row.SetUnlockedFields(rowFieldNumbers);
+                    }
                 }
             }
 
@@ -585,13 +641,19 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasFieldInForm)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
 
-            formObject.CurrentRow.SetRequiredField(fieldNumber);
+            if (formObject.CurrentRow.IsFieldPresent(fieldNumber))
+            {
+                formObject.CurrentRow.SetRequiredField(fieldNumber);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetRequiredField(fieldNumber);
+                    if (row.IsFieldPresent(fieldNumber))
+                    {
+                        row.SetRequiredField(fieldNumber);
+                    }
                 }
             }
 
@@ -617,13 +679,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasAnyField)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
 
-            formObject.CurrentRow.SetRequiredFields(fieldsToSet);
+            var currentRowFieldNumbers = fieldsToSet.Where(formObject.CurrentRow.IsFieldPresent).ToList();
+            if (currentRowFieldNumbers.Count > 0)
+            {
+                formObject.CurrentRow.SetRequiredFields(currentRowFieldNumbers);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetRequiredFields(fieldsToSet);
+                    var rowFieldNumbers = fieldsToSet.Where(row.IsFieldPresent).ToList();
+                    if (rowFieldNumbers.Count > 0)
+                    {
+                        row.SetRequiredFields(rowFieldNumbers);
+                    }
                 }
             }
 
@@ -649,13 +719,19 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasFieldInForm)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
 
-            formObject.CurrentRow.SetOptionalField(fieldNumber);
+            if (formObject.CurrentRow.IsFieldPresent(fieldNumber))
+            {
+                formObject.CurrentRow.SetOptionalField(fieldNumber);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetOptionalField(fieldNumber);
+                    if (row.IsFieldPresent(fieldNumber))
+                    {
+                        row.SetOptionalField(fieldNumber);
+                    }
                 }
             }
 
@@ -681,13 +757,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (!hasAnyField)
                 throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
 
-            formObject.CurrentRow.SetOptionalFields(fieldsToSet);
+            var currentRowFieldNumbers = fieldsToSet.Where(formObject.CurrentRow.IsFieldPresent).ToList();
+            if (currentRowFieldNumbers.Count > 0)
+            {
+                formObject.CurrentRow.SetOptionalFields(currentRowFieldNumbers);
+            }
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
                 foreach (var row in formObject.OtherRows)
                 {
-                    row.SetOptionalFields(fieldsToSet);
+                    var rowFieldNumbers = fieldsToSet.Where(row.IsFieldPresent).ToList();
+                    if (rowFieldNumbers.Count > 0)
+                    {
+                        row.SetOptionalFields(rowFieldNumbers);
+                    }
                 }
             }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -336,12 +336,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
-                foreach (var row in formObject.OtherRows)
+                foreach (var row in formObject.OtherRows.Where(r => r.IsFieldPresent(fieldNumber)))
                 {
-                    if (row.IsFieldPresent(fieldNumber))
-                    {
-                        row.SetDisabledField(fieldNumber);
-                    }
+                    row.SetDisabledField(fieldNumber);
                 }
             }
 
@@ -414,12 +411,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
-                foreach (var row in formObject.OtherRows)
+                foreach (var row in formObject.OtherRows.Where(r => r.IsFieldPresent(fieldNumber)))
                 {
-                    if (row.IsFieldPresent(fieldNumber))
-                    {
-                        row.SetEnabledField(fieldNumber);
-                    }
+                    row.SetEnabledField(fieldNumber);
                 }
             }
 
@@ -492,12 +486,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
-                foreach (var row in formObject.OtherRows)
+                foreach (var row in formObject.OtherRows.Where(r => r.IsFieldPresent(fieldNumber)))
                 {
-                    if (row.IsFieldPresent(fieldNumber))
-                    {
-                        row.SetLockedField(fieldNumber);
-                    }
+                    row.SetLockedField(fieldNumber);
                 }
             }
 
@@ -570,12 +561,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
-                foreach (var row in formObject.OtherRows)
+                foreach (var row in formObject.OtherRows.Where(r => r.IsFieldPresent(fieldNumber)))
                 {
-                    if (row.IsFieldPresent(fieldNumber))
-                    {
-                        row.SetUnlockedField(fieldNumber);
-                    }
+                    row.SetUnlockedField(fieldNumber);
                 }
             }
 
@@ -648,12 +636,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
-                foreach (var row in formObject.OtherRows)
+                foreach (var row in formObject.OtherRows.Where(r => r.IsFieldPresent(fieldNumber)))
                 {
-                    if (row.IsFieldPresent(fieldNumber))
-                    {
-                        row.SetRequiredField(fieldNumber);
-                    }
+                    row.SetRequiredField(fieldNumber);
                 }
             }
 
@@ -726,12 +711,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (formObject.MultipleIteration && formObject.HasOtherRows())
             {
-                foreach (var row in formObject.OtherRows)
+                foreach (var row in formObject.OtherRows.Where(r => r.IsFieldPresent(fieldNumber)))
                 {
-                    if (row.IsFieldPresent(fieldNumber))
-                    {
-                        row.SetOptionalField(fieldNumber);
-                    }
+                    row.SetOptionalField(fieldNumber);
                 }
             }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -565,5 +565,133 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             return formObject;
         }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in a <see cref="FormObject"/> as required by field number.
+        /// </summary>
+        /// <param name="formObject">The FormObject to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <returns>The modified FormObject.</returns>
+        public static FormObject? SetRequiredField(this FormObject formObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (formObject == null || formObject.CurrentRow == null)
+                return formObject;
+
+            var hasFieldInForm = formObject.CurrentRow.IsFieldPresent(fieldNumber)
+                || (formObject.MultipleIteration && formObject.HasOtherRows() && formObject.OtherRows.Any(r => r.IsFieldPresent(fieldNumber)));
+
+            if (!hasFieldInForm)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            formObject.CurrentRow.SetRequiredField(fieldNumber);
+
+            if (formObject.MultipleIteration && formObject.HasOtherRows())
+            {
+                foreach (var row in formObject.OtherRows)
+                {
+                    row.SetRequiredField(fieldNumber);
+                }
+            }
+
+            return formObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in a <see cref="FormObject"/> as required by field numbers.
+        /// </summary>
+        /// <param name="formObject">The FormObject to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <returns>The modified FormObject.</returns>
+        public static FormObject? SetRequiredFields(this FormObject formObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (formObject == null || formObject.CurrentRow == null)
+                return formObject;
+
+            var hasAnyField = fieldsToSet.Any(f => formObject.CurrentRow.IsFieldPresent(f))
+                || (formObject.MultipleIteration && formObject.HasOtherRows() && fieldsToSet.Any(f => formObject.OtherRows.Any(r => r.IsFieldPresent(f))));
+
+            if (!hasAnyField)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            formObject.CurrentRow.SetRequiredFields(fieldsToSet);
+
+            if (formObject.MultipleIteration && formObject.HasOtherRows())
+            {
+                foreach (var row in formObject.OtherRows)
+                {
+                    row.SetRequiredFields(fieldsToSet);
+                }
+            }
+
+            return formObject;
+        }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in a <see cref="FormObject"/> as optional by field number.
+        /// </summary>
+        /// <param name="formObject">The FormObject to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <returns>The modified FormObject.</returns>
+        public static FormObject? SetOptionalField(this FormObject formObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (formObject == null || formObject.CurrentRow == null)
+                return formObject;
+
+            var hasFieldInForm = formObject.CurrentRow.IsFieldPresent(fieldNumber)
+                || (formObject.MultipleIteration && formObject.HasOtherRows() && formObject.OtherRows.Any(r => r.IsFieldPresent(fieldNumber)));
+
+            if (!hasFieldInForm)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            formObject.CurrentRow.SetOptionalField(fieldNumber);
+
+            if (formObject.MultipleIteration && formObject.HasOtherRows())
+            {
+                foreach (var row in formObject.OtherRows)
+                {
+                    row.SetOptionalField(fieldNumber);
+                }
+            }
+
+            return formObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in a <see cref="FormObject"/> as optional by field numbers.
+        /// </summary>
+        /// <param name="formObject">The FormObject to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <returns>The modified FormObject.</returns>
+        public static FormObject? SetOptionalFields(this FormObject formObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (formObject == null || formObject.CurrentRow == null)
+                return formObject;
+
+            var hasAnyField = fieldsToSet.Any(f => formObject.CurrentRow.IsFieldPresent(f))
+                || (formObject.MultipleIteration && formObject.HasOtherRows() && fieldsToSet.Any(f => formObject.OtherRows.Any(r => r.IsFieldPresent(f))));
+
+            if (!hasAnyField)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            formObject.CurrentRow.SetOptionalFields(fieldsToSet);
+
+            if (formObject.MultipleIteration && formObject.HasOtherRows())
+            {
+                foreach (var row in formObject.OtherRows)
+                {
+                    row.SetOptionalFields(fieldsToSet);
+                }
+            }
+
+            return formObject;
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -355,5 +355,143 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             return optionObject;
         }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in an <see cref="OptionObject2015"/> as required by field number.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2015 to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <returns>The modified OptionObject2015.</returns>
+        public static OptionObject2015? SetRequiredField(this OptionObject2015 optionObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            if (!optionObject.Forms.Any(f => f.IsFieldPresent(fieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            foreach (var form in optionObject.Forms)
+            {
+                form.SetRequiredField(fieldNumber);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2015"/> as required.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2015 to modify.</param>
+        /// <param name="fieldObjects">The field objects to mark as required.</param>
+        /// <returns>The modified OptionObject2015.</returns>
+        public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
+        {
+            var fieldNumbers = ArgumentGuards.ValidateAndGetFieldNumbers(fieldObjects, nameof(fieldObjects));
+
+            return optionObject.SetRequiredFields(fieldNumbers);
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2015"/> as required by field numbers.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2015 to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <returns>The modified OptionObject2015.</returns>
+        public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            fieldsToSet = fieldsToSet
+                .Where(f => optionObject.Forms.Any(form => form.IsFieldPresent(f)))
+                .ToList();
+
+            if (fieldsToSet.Count == 0)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            foreach (var form in optionObject.Forms)
+            {
+                var formFieldNumbers = fieldsToSet.Where(form.IsFieldPresent).ToList();
+                if (formFieldNumbers.Count == 0)
+                    continue;
+
+                form.SetRequiredFields(formFieldNumbers);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in an <see cref="OptionObject2015"/> as optional by field number.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2015 to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <returns>The modified OptionObject2015.</returns>
+        public static OptionObject2015? SetOptionalField(this OptionObject2015 optionObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            if (!optionObject.Forms.Any(f => f.IsFieldPresent(fieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            foreach (var form in optionObject.Forms)
+            {
+                form.SetOptionalField(fieldNumber);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2015"/> as optional.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2015 to modify.</param>
+        /// <param name="fieldObjects">The field objects to mark as optional.</param>
+        /// <returns>The modified OptionObject2015.</returns>
+        public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
+        {
+            var fieldNumbers = ArgumentGuards.ValidateAndGetFieldNumbers(fieldObjects, nameof(fieldObjects));
+
+            return optionObject.SetOptionalFields(fieldNumbers);
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2015"/> as optional by field numbers.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2015 to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <returns>The modified OptionObject2015.</returns>
+        public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            fieldsToSet = fieldsToSet
+                .Where(f => optionObject.Forms.Any(form => form.IsFieldPresent(f)))
+                .ToList();
+
+            if (fieldsToSet.Count == 0)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            foreach (var form in optionObject.Forms)
+            {
+                var formFieldNumbers = fieldsToSet.Where(form.IsFieldPresent).ToList();
+                if (formFieldNumbers.Count == 0)
+                    continue;
+
+                form.SetOptionalFields(formFieldNumbers);
+            }
+
+            return optionObject;
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -374,6 +374,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             foreach (var form in optionObject.Forms)
             {
+                if (!form.IsFieldPresent(fieldNumber))
+                    continue;
+
                 form.SetRequiredField(fieldNumber);
             }
 
@@ -443,6 +446,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             foreach (var form in optionObject.Forms)
             {
+                if (!form.IsFieldPresent(fieldNumber))
+                    continue;
+
                 form.SetOptionalField(fieldNumber);
             }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -354,6 +354,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             foreach (var form in optionObject.Forms)
             {
+                if (!form.IsFieldPresent(fieldNumber))
+                    continue;
+
                 form.SetRequiredField(fieldNumber);
             }
 
@@ -423,6 +426,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             foreach (var form in optionObject.Forms)
             {
+                if (!form.IsFieldPresent(fieldNumber))
+                    continue;
+
                 form.SetOptionalField(fieldNumber);
             }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -335,5 +335,143 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             return optionObject;
         }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in an <see cref="OptionObject2"/> as required by field number.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2 to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <returns>The modified OptionObject2.</returns>
+        public static OptionObject2? SetRequiredField(this OptionObject2 optionObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            if (!optionObject.Forms.Any(f => f.IsFieldPresent(fieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            foreach (var form in optionObject.Forms)
+            {
+                form.SetRequiredField(fieldNumber);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2"/> as required.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2 to modify.</param>
+        /// <param name="fieldObjects">The field objects to mark as required.</param>
+        /// <returns>The modified OptionObject2.</returns>
+        public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
+        {
+            var fieldNumbers = ArgumentGuards.ValidateAndGetFieldNumbers(fieldObjects, nameof(fieldObjects));
+
+            return optionObject.SetRequiredFields(fieldNumbers);
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2"/> as required by field numbers.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2 to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <returns>The modified OptionObject2.</returns>
+        public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            fieldsToSet = fieldsToSet
+                .Where(f => optionObject.Forms.Any(form => form.IsFieldPresent(f)))
+                .ToList();
+
+            if (fieldsToSet.Count == 0)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            foreach (var form in optionObject.Forms)
+            {
+                var formFieldNumbers = fieldsToSet.Where(form.IsFieldPresent).ToList();
+                if (formFieldNumbers.Count == 0)
+                    continue;
+
+                form.SetRequiredFields(formFieldNumbers);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in an <see cref="OptionObject2"/> as optional by field number.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2 to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <returns>The modified OptionObject2.</returns>
+        public static OptionObject2? SetOptionalField(this OptionObject2 optionObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            if (!optionObject.Forms.Any(f => f.IsFieldPresent(fieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            foreach (var form in optionObject.Forms)
+            {
+                form.SetOptionalField(fieldNumber);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2"/> as optional.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2 to modify.</param>
+        /// <param name="fieldObjects">The field objects to mark as optional.</param>
+        /// <returns>The modified OptionObject2.</returns>
+        public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
+        {
+            var fieldNumbers = ArgumentGuards.ValidateAndGetFieldNumbers(fieldObjects, nameof(fieldObjects));
+
+            return optionObject.SetOptionalFields(fieldNumbers);
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject2"/> as optional by field numbers.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject2 to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <returns>The modified OptionObject2.</returns>
+        public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            fieldsToSet = fieldsToSet
+                .Where(f => optionObject.Forms.Any(form => form.IsFieldPresent(f)))
+                .ToList();
+
+            if (fieldsToSet.Count == 0)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            foreach (var form in optionObject.Forms)
+            {
+                var formFieldNumbers = fieldsToSet.Where(form.IsFieldPresent).ToList();
+                if (formFieldNumbers.Count == 0)
+                    continue;
+
+                form.SetOptionalFields(formFieldNumbers);
+            }
+
+            return optionObject;
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -524,6 +524,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             foreach (var form in optionObject.Forms)
             {
+                if (!form.IsFieldPresent(fieldNumber))
+                    continue;
+
                 form.SetRequiredField(fieldNumber);
             }
 
@@ -593,6 +596,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             foreach (var form in optionObject.Forms)
             {
+                if (!form.IsFieldPresent(fieldNumber))
+                    continue;
+
                 form.SetOptionalField(fieldNumber);
             }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -505,5 +505,143 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             return optionObject;
         }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in an <see cref="OptionObject"/> as required by field number.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <returns>The modified OptionObject.</returns>
+        public static OptionObject? SetRequiredField(this OptionObject optionObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            if (!optionObject.Forms.Any(f => f.IsFieldPresent(fieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            foreach (var form in optionObject.Forms)
+            {
+                form.SetRequiredField(fieldNumber);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject"/> as required.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject to modify.</param>
+        /// <param name="fieldObjects">The field objects to mark as required.</param>
+        /// <returns>The modified OptionObject.</returns>
+        public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
+        {
+            var fieldNumbers = ArgumentGuards.ValidateAndGetFieldNumbers(fieldObjects, nameof(fieldObjects));
+
+            return optionObject.SetRequiredFields(fieldNumbers);
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject"/> as required by field numbers.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <returns>The modified OptionObject.</returns>
+        public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            fieldsToSet = fieldsToSet
+                .Where(f => optionObject.Forms.Any(form => form.IsFieldPresent(f)))
+                .ToList();
+
+            if (fieldsToSet.Count == 0)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            foreach (var form in optionObject.Forms)
+            {
+                var formFieldNumbers = fieldsToSet.Where(form.IsFieldPresent).ToList();
+                if (formFieldNumbers.Count == 0)
+                    continue;
+
+                form.SetRequiredFields(formFieldNumbers);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in an <see cref="OptionObject"/> as optional by field number.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <returns>The modified OptionObject.</returns>
+        public static OptionObject? SetOptionalField(this OptionObject optionObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            if (!optionObject.Forms.Any(f => f.IsFieldPresent(fieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            foreach (var form in optionObject.Forms)
+            {
+                form.SetOptionalField(fieldNumber);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject"/> as optional.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject to modify.</param>
+        /// <param name="fieldObjects">The field objects to mark as optional.</param>
+        /// <returns>The modified OptionObject.</returns>
+        public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
+        {
+            var fieldNumbers = ArgumentGuards.ValidateAndGetFieldNumbers(fieldObjects, nameof(fieldObjects));
+
+            return optionObject.SetOptionalFields(fieldNumbers);
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in an <see cref="OptionObject"/> as optional by field numbers.
+        /// </summary>
+        /// <param name="optionObject">The OptionObject to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <returns>The modified OptionObject.</returns>
+        public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (optionObject == null || optionObject.Forms == null)
+                return optionObject;
+
+            fieldsToSet = fieldsToSet
+                .Where(f => optionObject.Forms.Any(form => form.IsFieldPresent(f)))
+                .ToList();
+
+            if (fieldsToSet.Count == 0)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            foreach (var form in optionObject.Forms)
+            {
+                var formFieldNumbers = fieldsToSet.Where(form.IsFieldPresent).ToList();
+                if (formFieldNumbers.Count == 0)
+                    continue;
+
+                form.SetOptionalFields(formFieldNumbers);
+            }
+
+            return optionObject;
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
@@ -433,6 +433,124 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         }
 
         /// <summary>
+        /// Marks a <see cref="FieldObject"/> in a <see cref="RowObject"/> as required by field number.
+        /// </summary>
+        /// <param name="rowObject">The RowObject to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <returns>The modified RowObject.</returns>
+        public static RowObject? SetRequiredField(this RowObject rowObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (rowObject == null || rowObject.Fields == null)
+                return rowObject;
+
+            var field = rowObject.Fields.FirstOrDefault(f => f.FieldNumber == fieldNumber);
+            if (field == null)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            var changed = !field.IsRequired();
+            field.MarkRequired();
+
+            if (changed && string.IsNullOrEmpty(rowObject.RowAction))
+                rowObject.RowAction = RowObject.RowActions.Edit;
+
+            return rowObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in a <see cref="RowObject"/> as required by field numbers.
+        /// </summary>
+        /// <param name="rowObject">The RowObject to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <returns>The modified RowObject.</returns>
+        public static RowObject? SetRequiredFields(this RowObject rowObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (rowObject == null || rowObject.Fields == null)
+                return rowObject;
+
+            if (!rowObject.Fields.Any(f => fieldsToSet.Contains(f.FieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            var changed = false;
+            foreach (var field in rowObject.Fields.Where(f => fieldsToSet.Contains(f.FieldNumber)))
+            {
+                if (!field.IsRequired())
+                {
+                    changed = true;
+                }
+
+                field.MarkRequired();
+            }
+
+            if (changed && string.IsNullOrEmpty(rowObject.RowAction))
+                rowObject.RowAction = RowObject.RowActions.Edit;
+
+            return rowObject;
+        }
+
+        /// <summary>
+        /// Marks a <see cref="FieldObject"/> in a <see cref="RowObject"/> as optional by field number.
+        /// </summary>
+        /// <param name="rowObject">The RowObject to modify.</param>
+        /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <returns>The modified RowObject.</returns>
+        public static RowObject? SetOptionalField(this RowObject rowObject, string fieldNumber)
+        {
+            ArgumentGuards.ValidateFieldNumber(fieldNumber, nameof(fieldNumber));
+
+            if (rowObject == null || rowObject.Fields == null)
+                return rowObject;
+
+            var field = rowObject.Fields.FirstOrDefault(f => f.FieldNumber == fieldNumber);
+            if (field == null)
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumber));
+
+            var changed = field.IsRequired();
+            field.MarkOptional();
+
+            if (changed && string.IsNullOrEmpty(rowObject.RowAction))
+                rowObject.RowAction = RowObject.RowActions.Edit;
+
+            return rowObject;
+        }
+
+        /// <summary>
+        /// Marks <see cref="FieldObject"/> instances in a <see cref="RowObject"/> as optional by field numbers.
+        /// </summary>
+        /// <param name="rowObject">The RowObject to modify.</param>
+        /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <returns>The modified RowObject.</returns>
+        public static RowObject? SetOptionalFields(this RowObject rowObject, List<string>? fieldNumbers)
+        {
+            var fieldsToSet = ArgumentGuards.ValidateAndNormalizeFieldNumbers(fieldNumbers, nameof(fieldNumbers));
+
+            if (rowObject == null || rowObject.Fields == null)
+                return rowObject;
+
+            if (!rowObject.Fields.Any(f => fieldsToSet.Contains(f.FieldNumber)))
+                throw new ArgumentException(ArgumentGuards.NoMatchingFieldObjectsMessage, nameof(fieldNumbers));
+
+            var changed = false;
+            foreach (var field in rowObject.Fields.Where(f => fieldsToSet.Contains(f.FieldNumber)))
+            {
+                if (field.IsRequired())
+                {
+                    changed = true;
+                }
+
+                field.MarkOptional();
+            }
+
+            if (changed && string.IsNullOrEmpty(rowObject.RowAction))
+                rowObject.RowAction = RowObject.RowActions.Edit;
+
+            return rowObject;
+        }
+
+        /// <summary>
         /// Enables all <see cref="FieldObject"/> instances in a <see cref="RowObject"/>.
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>


### PR DESCRIPTION
Add support for Required and Optional fields in OptionObject and RowObject

- Extended OptionObject, OptionObject2, and OptionObject2015 to handle Required and Optional fields.
- Implemented SetRequiredField and SetOptionalField methods in FormObjectHelpers, OptionObjectHelpers, and RowObjectHelpers.
- Added unit tests for Required and Optional field functionalities in OptionObject, OptionObject2, OptionObject2015, and RowObject.
- Updated existing tests to include scenarios for Required and Optional fields.