### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-check-build.yml
+++ b/.github/workflows/dotnet-check-build.yml
@@ -1,5 +1,7 @@
 name: dotnet-check-build
 run-name: Check .NET Build by ${{ github.actor }}
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/9](https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/9)

In general, the fix is to explicitly declare a `permissions` block either at the workflow root (applies to all jobs) or under the specific job(s), granting only the minimal permissions required for the job to run. For a typical build/test/package workflow that does not push commits, create releases, or modify issues/PRs, a safe default is `contents: read`, which corresponds to a read-only GITHUB_TOKEN.

For this particular workflow file `.github/workflows/dotnet-check-build.yml`, the job simply reuses another workflow (`./.github/workflows/dotnet-build.yml`) to build, test, and package .NET code. There is no indication it needs to write to the repository or to issues/PRs. The best minimal, non-breaking fix is to add a root-level `permissions` block directly under the workflow name/run-name section, before the `on:` section, setting `contents: read`. This will apply to all jobs in this workflow (currently just `build`) unless overridden, and will not change existing functional behavior other than restricting any unnecessary write permissions of the GITHUB_TOKEN.

No new methods, imports, or external libraries are needed, because this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
