### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
     uses: ./.github/workflows/dotnet-build.yml
     with:
       working-directory: ./dotnet


### PR DESCRIPTION
Potential fix for [https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/8](https://github.com/rarelysimple/RarelySimple.AvatarScriptLink/security/code-scanning/8)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for the `build` job instead of letting it inherit repository defaults. The safest minimal starting point is `permissions: contents: read`, which allows the job to read the repository content (typically needed by reusable workflows) but not modify it. Since this job only invokes a local reusable workflow (`./.github/workflows/dotnet-build.yml`) and passes inputs, and there is no indication that it must write to the repo, there is no need to grant broader permissions here.

Concretely, in `.github/workflows/dotnet-publish.yml`, edit the `build` job definition (lines 13–20). Insert a `permissions` block under `name: Build` (and at the same indentation level as `uses:`) that sets `contents: read`. This change does not alter any existing steps or behavior of the workflow; it only constrains the GITHUB_TOKEN for that job. No imports or external dependencies are needed: we only modify the YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
