### PR TITLE
Enhance documentation for OptionObject helper methods

### DIFF
--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -315,7 +315,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetDisabledField(this FormObject formObject, string fieldNumber)
@@ -352,7 +352,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetDisabledFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -394,7 +394,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetEnabledField(this FormObject formObject, string fieldNumber)
@@ -431,7 +431,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetEnabledFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -473,7 +473,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetLockedField(this FormObject formObject, string fieldNumber)
@@ -510,7 +510,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetLockedFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -552,7 +552,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetUnlockedField(this FormObject formObject, string fieldNumber)
@@ -589,7 +589,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetUnlockedFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -631,7 +631,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetRequiredField(this FormObject formObject, string fieldNumber)
@@ -668,7 +668,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetRequiredFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -710,7 +710,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetOptionalField(this FormObject formObject, string fieldNumber)
@@ -747,7 +747,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetOptionalFields(this FormObject formObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -315,7 +315,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetDisabledField(this FormObject formObject, string fieldNumber)
@@ -352,7 +352,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetDisabledFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -394,7 +394,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetEnabledField(this FormObject formObject, string fieldNumber)
@@ -431,7 +431,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetEnabledFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -473,7 +473,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetLockedField(this FormObject formObject, string fieldNumber)
@@ -510,7 +510,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetLockedFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -552,7 +552,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetUnlockedField(this FormObject formObject, string fieldNumber)
@@ -589,7 +589,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetUnlockedFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -631,7 +631,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetRequiredField(this FormObject formObject, string fieldNumber)
@@ -668,7 +668,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetRequiredFields(this FormObject formObject, List<string>? fieldNumbers)
@@ -710,7 +710,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetOptionalField(this FormObject formObject, string fieldNumber)
@@ -747,7 +747,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetOptionalFields(this FormObject formObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -315,6 +315,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetDisabledField(this FormObject formObject, string fieldNumber)
         {
@@ -350,6 +352,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetDisabledFields(this FormObject formObject, List<string>? fieldNumbers)
         {
@@ -390,6 +394,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetEnabledField(this FormObject formObject, string fieldNumber)
         {
@@ -425,6 +431,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetEnabledFields(this FormObject formObject, List<string>? fieldNumbers)
         {
@@ -465,6 +473,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetLockedField(this FormObject formObject, string fieldNumber)
         {
@@ -500,6 +510,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetLockedFields(this FormObject formObject, List<string>? fieldNumbers)
         {
@@ -540,6 +552,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetUnlockedField(this FormObject formObject, string fieldNumber)
         {
@@ -575,6 +589,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetUnlockedFields(this FormObject formObject, List<string>? fieldNumbers)
         {
@@ -615,6 +631,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetRequiredField(this FormObject formObject, string fieldNumber)
         {
@@ -650,6 +668,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetRequiredFields(this FormObject formObject, List<string>? fieldNumbers)
         {
@@ -690,6 +710,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetOptionalField(this FormObject formObject, string fieldNumber)
         {
@@ -725,6 +747,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The FormObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified FormObject.</returns>
         public static FormObject? SetOptionalFields(this FormObject formObject, List<string>? fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -99,6 +99,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledField(this OptionObject2015 optionObject, string fieldNumber)
         {
@@ -123,6 +125,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -136,6 +140,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
         {
@@ -168,6 +174,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledField(this OptionObject2015 optionObject, string fieldNumber)
         {
@@ -192,6 +200,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -205,6 +215,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
         {
@@ -237,6 +249,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedField(this OptionObject2015 optionObject, string fieldNumber)
         {
@@ -261,6 +275,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -274,6 +290,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
         {
@@ -306,6 +324,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedField(this OptionObject2015 optionObject, string fieldNumber)
         {
@@ -330,6 +350,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -343,6 +365,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
         {
@@ -375,6 +399,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredField(this OptionObject2015 optionObject, string fieldNumber)
         {
@@ -402,6 +428,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -415,6 +443,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
         {
@@ -447,6 +477,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalField(this OptionObject2015 optionObject, string fieldNumber)
         {
@@ -474,6 +506,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -487,6 +521,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -99,7 +99,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledField(this OptionObject2015 optionObject, string fieldNumber)
@@ -125,7 +125,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -140,7 +140,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -174,7 +174,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledField(this OptionObject2015 optionObject, string fieldNumber)
@@ -200,7 +200,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -215,7 +215,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -249,7 +249,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedField(this OptionObject2015 optionObject, string fieldNumber)
@@ -275,7 +275,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -290,7 +290,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -324,7 +324,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedField(this OptionObject2015 optionObject, string fieldNumber)
@@ -350,7 +350,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -365,7 +365,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -399,7 +399,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredField(this OptionObject2015 optionObject, string fieldNumber)
@@ -428,7 +428,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -443,7 +443,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -477,7 +477,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalField(this OptionObject2015 optionObject, string fieldNumber)
@@ -506,7 +506,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -521,7 +521,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -99,7 +99,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledField(this OptionObject2015 optionObject, string fieldNumber)
@@ -125,7 +125,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -140,7 +140,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetDisabledFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -174,7 +174,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledField(this OptionObject2015 optionObject, string fieldNumber)
@@ -200,7 +200,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -215,7 +215,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetEnabledFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -249,7 +249,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedField(this OptionObject2015 optionObject, string fieldNumber)
@@ -275,7 +275,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -290,7 +290,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetLockedFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -324,7 +324,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedField(this OptionObject2015 optionObject, string fieldNumber)
@@ -350,7 +350,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -365,7 +365,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetUnlockedFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -399,7 +399,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredField(this OptionObject2015 optionObject, string fieldNumber)
@@ -428,7 +428,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -443,7 +443,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetRequiredFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)
@@ -477,7 +477,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalField(this OptionObject2015 optionObject, string fieldNumber)
@@ -506,7 +506,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<FieldObject>? fieldObjects)
@@ -521,7 +521,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2015.</returns>
         public static OptionObject2015? SetOptionalFields(this OptionObject2015 optionObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -79,7 +79,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledField(this OptionObject2 optionObject, string fieldNumber)
@@ -105,7 +105,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -120,7 +120,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -154,7 +154,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledField(this OptionObject2 optionObject, string fieldNumber)
@@ -180,7 +180,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -195,7 +195,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -229,7 +229,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedField(this OptionObject2 optionObject, string fieldNumber)
@@ -255,7 +255,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -270,7 +270,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -304,7 +304,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedField(this OptionObject2 optionObject, string fieldNumber)
@@ -330,7 +330,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -345,7 +345,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -379,7 +379,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredField(this OptionObject2 optionObject, string fieldNumber)
@@ -408,7 +408,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -423,7 +423,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -457,7 +457,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalField(this OptionObject2 optionObject, string fieldNumber)
@@ -486,7 +486,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -501,7 +501,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -79,7 +79,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledField(this OptionObject2 optionObject, string fieldNumber)
@@ -105,7 +105,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -120,7 +120,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -154,7 +154,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledField(this OptionObject2 optionObject, string fieldNumber)
@@ -180,7 +180,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -195,7 +195,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -229,7 +229,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedField(this OptionObject2 optionObject, string fieldNumber)
@@ -255,7 +255,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -270,7 +270,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -304,7 +304,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedField(this OptionObject2 optionObject, string fieldNumber)
@@ -330,7 +330,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -345,7 +345,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -379,7 +379,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredField(this OptionObject2 optionObject, string fieldNumber)
@@ -408,7 +408,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -423,7 +423,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
@@ -457,7 +457,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalField(this OptionObject2 optionObject, string fieldNumber)
@@ -486,7 +486,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
@@ -501,7 +501,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -79,6 +79,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledField(this OptionObject2 optionObject, string fieldNumber)
         {
@@ -103,6 +105,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -116,6 +120,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetDisabledFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
         {
@@ -148,6 +154,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledField(this OptionObject2 optionObject, string fieldNumber)
         {
@@ -172,6 +180,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -185,6 +195,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetEnabledFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
         {
@@ -217,6 +229,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedField(this OptionObject2 optionObject, string fieldNumber)
         {
@@ -241,6 +255,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -254,6 +270,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetLockedFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
         {
@@ -286,6 +304,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedField(this OptionObject2 optionObject, string fieldNumber)
         {
@@ -310,6 +330,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -323,6 +345,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetUnlockedFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
         {
@@ -355,6 +379,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredField(this OptionObject2 optionObject, string fieldNumber)
         {
@@ -382,6 +408,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -395,6 +423,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetRequiredFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
         {
@@ -427,6 +457,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalField(this OptionObject2 optionObject, string fieldNumber)
         {
@@ -454,6 +486,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<FieldObject>? fieldObjects)
         {
@@ -467,6 +501,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject2.</returns>
         public static OptionObject2? SetOptionalFields(this OptionObject2 optionObject, List<string>? fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -249,6 +249,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledField(this OptionObject optionObject, string fieldNumber)
         {
@@ -273,6 +275,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
         {
@@ -286,6 +290,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledFields(this OptionObject optionObject, List<string>? fieldNumbers)
         {
@@ -318,6 +324,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledField(this OptionObject optionObject, string fieldNumber)
         {
@@ -342,6 +350,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
         {
@@ -355,6 +365,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledFields(this OptionObject optionObject, List<string>? fieldNumbers)
         {
@@ -387,6 +399,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedField(this OptionObject optionObject, string fieldNumber)
         {
@@ -411,6 +425,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
         {
@@ -424,6 +440,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedFields(this OptionObject optionObject, List<string>? fieldNumbers)
         {
@@ -456,6 +474,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedField(this OptionObject optionObject, string fieldNumber)
         {
@@ -480,6 +500,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
         {
@@ -493,6 +515,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedFields(this OptionObject optionObject, List<string>? fieldNumbers)
         {
@@ -525,6 +549,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredField(this OptionObject optionObject, string fieldNumber)
         {
@@ -552,6 +578,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
         {
@@ -565,6 +593,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<string>? fieldNumbers)
         {
@@ -597,6 +627,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalField(this OptionObject optionObject, string fieldNumber)
         {
@@ -624,6 +656,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
         {
@@ -637,6 +671,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<string>? fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -249,7 +249,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledField(this OptionObject optionObject, string fieldNumber)
@@ -275,7 +275,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -290,7 +290,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -324,7 +324,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledField(this OptionObject optionObject, string fieldNumber)
@@ -350,7 +350,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -365,7 +365,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -399,7 +399,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedField(this OptionObject optionObject, string fieldNumber)
@@ -425,7 +425,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -440,7 +440,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -474,7 +474,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedField(this OptionObject optionObject, string fieldNumber)
@@ -500,7 +500,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -515,7 +515,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -549,7 +549,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredField(this OptionObject optionObject, string fieldNumber)
@@ -578,7 +578,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -593,7 +593,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -627,7 +627,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalField(this OptionObject optionObject, string fieldNumber)
@@ -656,7 +656,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -671,7 +671,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -249,7 +249,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledField(this OptionObject optionObject, string fieldNumber)
@@ -275,7 +275,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -290,7 +290,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetDisabledFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -324,7 +324,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledField(this OptionObject optionObject, string fieldNumber)
@@ -350,7 +350,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -365,7 +365,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetEnabledFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -399,7 +399,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedField(this OptionObject optionObject, string fieldNumber)
@@ -425,7 +425,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -440,7 +440,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetLockedFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -474,7 +474,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedField(this OptionObject optionObject, string fieldNumber)
@@ -500,7 +500,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -515,7 +515,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetUnlockedFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -549,7 +549,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredField(this OptionObject optionObject, string fieldNumber)
@@ -578,7 +578,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -593,7 +593,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetRequiredFields(this OptionObject optionObject, List<string>? fieldNumbers)
@@ -627,7 +627,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalField(this OptionObject optionObject, string fieldNumber)
@@ -656,7 +656,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldObjects">The field objects to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains no field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty, contains invalid field numbers, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<FieldObject>? fieldObjects)
@@ -671,7 +671,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="optionObject">The OptionObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified OptionObject.</returns>
         public static OptionObject? SetOptionalFields(this OptionObject optionObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
@@ -203,7 +203,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetDisabledField(this RowObject rowObject, string fieldNumber)
@@ -231,7 +231,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetDisabledFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -265,7 +265,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetEnabledField(this RowObject rowObject, string fieldNumber)
@@ -293,7 +293,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetEnabledFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -327,7 +327,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetLockedField(this RowObject rowObject, string fieldNumber)
@@ -355,7 +355,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetLockedFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -390,7 +390,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetUnlockedField(this RowObject rowObject, string fieldNumber)
@@ -418,7 +418,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetUnlockedFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -453,7 +453,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetRequiredField(this RowObject rowObject, string fieldNumber)
@@ -481,7 +481,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetRequiredFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -516,7 +516,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetOptionalField(this RowObject rowObject, string fieldNumber)
@@ -544,7 +544,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetOptionalFields(this RowObject rowObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
@@ -203,6 +203,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetDisabledField(this RowObject rowObject, string fieldNumber)
         {
@@ -229,6 +231,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetDisabledFields(this RowObject rowObject, List<string>? fieldNumbers)
         {
@@ -261,6 +265,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetEnabledField(this RowObject rowObject, string fieldNumber)
         {
@@ -287,6 +293,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetEnabledFields(this RowObject rowObject, List<string>? fieldNumbers)
         {
@@ -319,6 +327,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetLockedField(this RowObject rowObject, string fieldNumber)
         {
@@ -345,6 +355,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetLockedFields(this RowObject rowObject, List<string>? fieldNumbers)
         {
@@ -378,6 +390,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetUnlockedField(this RowObject rowObject, string fieldNumber)
         {
@@ -404,6 +418,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetUnlockedFields(this RowObject rowObject, List<string>? fieldNumbers)
         {
@@ -437,6 +453,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetRequiredField(this RowObject rowObject, string fieldNumber)
         {
@@ -463,6 +481,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetRequiredFields(this RowObject rowObject, List<string>? fieldNumbers)
         {
@@ -496,6 +516,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetOptionalField(this RowObject rowObject, string fieldNumber)
         {
@@ -522,6 +544,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetOptionalFields(this RowObject rowObject, List<string>? fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/RowObjectHelpers.cs
@@ -203,7 +203,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetDisabledField(this RowObject rowObject, string fieldNumber)
@@ -231,7 +231,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to disable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetDisabledFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -265,7 +265,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetEnabledField(this RowObject rowObject, string fieldNumber)
@@ -293,7 +293,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to enable.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetEnabledFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -327,7 +327,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetLockedField(this RowObject rowObject, string fieldNumber)
@@ -355,7 +355,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to lock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetLockedFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -390,7 +390,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetUnlockedField(this RowObject rowObject, string fieldNumber)
@@ -418,7 +418,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to unlock.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetUnlockedFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -453,7 +453,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetRequiredField(this RowObject rowObject, string fieldNumber)
@@ -481,7 +481,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as required.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetRequiredFields(this RowObject rowObject, List<string>? fieldNumbers)
@@ -516,7 +516,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumber">The field number to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty or when no matching field exists.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetOptionalField(this RowObject rowObject, string fieldNumber)
@@ -544,7 +544,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="rowObject">The RowObject to modify.</param>
         /// <param name="fieldNumbers">The field numbers to mark as optional.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty values.</exception>
         /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty, contains invalid values, or no matching fields exist.</exception>
         /// <returns>The modified RowObject.</returns>
         public static RowObject? SetOptionalFields(this RowObject rowObject, List<string>? fieldNumbers)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/Validators/ArgumentGuards.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/Validators/ArgumentGuards.cs
@@ -14,6 +14,13 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Validators
         private const string NoFieldNumbersProvidedMessage = "No field numbers were provided.";
         private const string FieldNumberCannotBeEmptyMessage = "Field number cannot be empty.";
 
+        /// <summary>
+        /// Validates a single field number argument.
+        /// </summary>
+        /// <param name="fieldNumber">The field number value to validate.</param>
+        /// <param name="paramName">The parameter name to include in thrown exceptions.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumber"/> is empty.</exception>
         public static void ValidateFieldNumber(string fieldNumber, string paramName)
         {
             if (fieldNumber == null)
@@ -23,6 +30,13 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Validators
                 throw new ArgumentException(FieldNumberCannotBeEmptyMessage, paramName);
         }
 
+        /// <summary>
+        /// Validates and normalizes a list of field numbers.
+        /// </summary>
+        /// <param name="fieldNumbers">The field numbers to validate and normalize.</param>
+        /// <param name="paramName">The parameter name to include in thrown exceptions.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldNumbers"/> is empty or contains no valid values after normalization.</exception>
         public static List<string> ValidateAndNormalizeFieldNumbers(List<string>? fieldNumbers, string paramName)
         {
             if (fieldNumbers == null)
@@ -42,6 +56,13 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Validators
             return normalized;
         }
 
+        /// <summary>
+        /// Validates a list of field objects and returns distinct field numbers.
+        /// </summary>
+        /// <param name="fieldObjects">The field objects to validate.</param>
+        /// <param name="paramName">The parameter name to include in thrown exceptions.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="fieldObjects"/> is empty or contains no valid field numbers.</exception>
         public static List<string> ValidateAndGetFieldNumbers(List<FieldObject>? fieldObjects, string paramName)
         {
             if (fieldObjects == null)

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/AddRowObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/AddRowObjectTests.cs
@@ -353,7 +353,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.HelpersTests
         [TestMethod]
         public void AddRowObject_OptionObject_NullOptionObject()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.AddRowObject((OptionObject)null, "1", new RowObject()));
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.AddRowObject((OptionObject)null!, "1", new RowObject()));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/DeleteRowObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/DeleteRowObjectTests.cs
@@ -728,13 +728,13 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
         public void DeleteRowObject_OptionObject_RowObject_NullRowObject()
         {
             OptionObject optionObject = new();
-            Assert.ThrowsException<ArgumentNullException>(() => optionObject.DeleteRowObject((RowObject)null));
+            Assert.ThrowsException<ArgumentNullException>(() => optionObject.DeleteRowObject((RowObject)null!));
         }
 
         [TestMethod]
         public void DeleteRowObject_OptionObject_RowId_NullOptionObject()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.DeleteRowObject((OptionObject)null, "1||1"));
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.DeleteRowObject((OptionObject)null!, "1||1"));
         }
 
         [TestMethod]
@@ -748,13 +748,13 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
         public void DeleteRowObject_FormObject_RowObject_NullRowObject()
         {
             FormObject formObject = new() { FormId = "1" };
-            Assert.ThrowsException<ArgumentNullException>(() => formObject.DeleteRowObject((RowObject)null));
+            Assert.ThrowsException<ArgumentNullException>(() => formObject.DeleteRowObject((RowObject)null!));
         }
 
         [TestMethod]
         public void DeleteRowObject_FormObject_RowId_NullFormObject()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.DeleteRowObject((FormObject)null, "1||1"));
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.DeleteRowObject((FormObject)null!, "1||1"));
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/RemoveFieldObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/RemoveFieldObjectTests.cs
@@ -50,7 +50,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             string fieldNumber = "123";
             RowObject rowObject = new("1||1");
 
-            Assert.ThrowsException<ArgumentNullException>(() => rowObject.RemoveFieldObject(fieldNumber));
+            Assert.ThrowsException<ArgumentException>(() => rowObject.RemoveFieldObject(fieldNumber));
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             string fieldNumber = "123";
             RowObject rowObject = new("1||1");
 
-            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.RemoveFieldObject(rowObject, fieldNumber));
+            Assert.ThrowsException<ArgumentException>(() => OptionObjectHelpers.RemoveFieldObject(rowObject, fieldNumber));
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/SetFieldObjectsTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/SetFieldObjectsTests.cs
@@ -43,6 +43,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
         }
 
         [TestMethod]
+        public void SetFieldObjects_OptionObject_NullFieldObjects_ThrowsArgumentNullException()
+        {
+            OptionObject optionObject = new();
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.SetFieldObjects(optionObject, FieldAction.Disable, (List<FieldObject>)null!));
+        }
+
+        [TestMethod]
         public void SetFieldObjects_OptionObject_Disabled_FieldObjects()
         {
             string fieldNumber = "123";
@@ -118,6 +126,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
         }
 
         [TestMethod]
+        public void SetFieldObjects_OptionObject_NullFieldNumbers_ThrowsArgumentNullException()
+        {
+            OptionObject optionObject = new();
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.SetFieldObjects(optionObject, FieldAction.Disable, (List<string>)null!));
+        }
+
+        [TestMethod]
         public void SetFieldObjects_OptionObject_Disabled_FieldNumbers()
         {
             string fieldNumber = "123";
@@ -152,6 +168,43 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             formObject.AddRowObject(rowObject);
             OptionObject optionObject = new();
             optionObject.AddFormObject(formObject);
+
+            Assert.ThrowsException<ArgumentException>(() => OptionObjectHelpers.SetFieldObjects(optionObject, FieldAction.Disable, fieldNumbers));
+        }
+
+        [TestMethod]
+        public void SetFieldObjects_OptionObject_AllFormsFail_ThrowsArgumentException()
+        {
+            string fieldNumber = "123";
+            List<string> fieldNumbers =
+            [
+                fieldNumber
+            ];
+
+            RowObject rowObject1 = new();
+            rowObject1.AddFieldObject(new FieldObject(fieldNumber));
+            FormObject formObject1 = new("1")
+            {
+                MultipleIteration = true,
+                CurrentRow = rowObject1,
+                OtherRows = null
+            };
+
+            RowObject rowObject2 = new();
+            rowObject2.AddFieldObject(new FieldObject(fieldNumber));
+            FormObject formObject2 = new("2")
+            {
+                MultipleIteration = true,
+                CurrentRow = rowObject2,
+                OtherRows = null
+            };
+
+            OptionObject optionObject = new();
+            optionObject.Forms =
+            [
+                formObject1,
+                formObject2
+            ];
 
             Assert.ThrowsException<ArgumentException>(() => OptionObjectHelpers.SetFieldObjects(optionObject, FieldAction.Disable, fieldNumbers));
         }
@@ -489,6 +542,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
         }
 
         [TestMethod]
+        public void SetFieldObjects_FormObject_NullFieldNumbers_ThrowsArgumentNullException()
+        {
+            FormObject formObject = new("1");
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.SetFieldObjects(formObject, FieldAction.Disable, (List<string>)null!));
+        }
+
+        [TestMethod]
         public void SetFieldObjects_FormObject_Disabled_FieldNumbers()
         {
             string fieldNumber = "123";
@@ -523,6 +584,37 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             Assert.ThrowsException<ArgumentException>(() => OptionObjectHelpers.SetFieldObjects(formObject, FieldAction.Disable, fieldNumbers));
         }
 
+        [TestMethod]
+        public void SetFieldObjects_FormObject_Disabled_FieldNumbers_MultipleIterationWithOtherRows_CoversLoop()
+        {
+            string fieldNumber = "123";
+            List<string> fieldNumbers =
+            [
+                fieldNumber
+            ];
+
+            RowObject currentRow = new();
+            currentRow.AddFieldObject(new FieldObject(fieldNumber));
+
+            RowObject otherRow = new();
+            otherRow.AddFieldObject(new FieldObject(fieldNumber));
+
+            FormObject formObject = new("1")
+            {
+                MultipleIteration = true,
+                CurrentRow = currentRow,
+                OtherRows =
+                [
+                    otherRow
+                ]
+            };
+
+            OptionObjectHelpers.SetFieldObjects(formObject, FieldAction.Disable, fieldNumbers);
+
+            Assert.IsFalse(formObject.CurrentRow.IsFieldEnabled(fieldNumber));
+            Assert.IsFalse(formObject.OtherRows[0].IsFieldEnabled(fieldNumber));
+        }
+
 
         [TestMethod]
         public void SetFieldObjects_RowObject_NullAction_FieldNumbers()
@@ -550,6 +642,14 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             rowObject.AddFieldObject(new FieldObject(fieldNumber));
 
             Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.SetFieldObjects(rowObject, "", fieldNumbers));
+        }
+
+        [TestMethod]
+        public void SetFieldObjects_RowObject_NullFieldNumbers_ThrowsArgumentNullException()
+        {
+            RowObject rowObject = new();
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.SetFieldObjects(rowObject, FieldAction.Disable, (List<string>)null!));
         }
 
         [TestMethod]
@@ -581,6 +681,44 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             rowObject.AddFieldObject(new FieldObject(fieldNumber));
 
             Assert.ThrowsException<ArgumentException>(() => OptionObjectHelpers.SetFieldObjects(rowObject, FieldAction.Disable, fieldNumbers));
+        }
+
+        [TestMethod]
+        public void SetFieldObjects_RowObject_Modify_FieldNumbers_MarksRowModified()
+        {
+            string fieldNumber = "123";
+            List<string> fieldNumbers =
+            [
+                fieldNumber
+            ];
+            RowObject rowObject = new();
+            rowObject.AddFieldObject(new FieldObject(fieldNumber));
+
+            OptionObjectHelpers.SetFieldObjects(rowObject, FieldAction.Modify, fieldNumbers);
+
+            Assert.IsTrue(rowObject.IsFieldModified(fieldNumber));
+            Assert.AreEqual(RowAction.Edit, rowObject.RowAction);
+        }
+
+        [TestMethod]
+        public void SetFieldObjects_RowObject_UnknownAction_FieldNumbers_NoChangesApplied()
+        {
+            string fieldNumber = "123";
+            List<string> fieldNumbers =
+            [
+                fieldNumber
+            ];
+            RowObject rowObject = new();
+            rowObject.AddFieldObject(new FieldObject(fieldNumber));
+
+            bool initialIsEnabled = rowObject.IsFieldEnabled(fieldNumber);
+            bool initialIsModified = rowObject.IsFieldModified(fieldNumber);
+
+            OptionObjectHelpers.SetFieldObjects(rowObject, "UNKNOWN", fieldNumbers);
+
+            Assert.AreEqual(initialIsEnabled, rowObject.IsFieldEnabled(fieldNumber));
+            Assert.AreEqual(initialIsModified, rowObject.IsFieldModified(fieldNumber));
+            Assert.IsNull(rowObject.RowAction);
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/SetFieldObjectsTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/SetFieldObjectsTests.cs
@@ -701,7 +701,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
         }
 
         [TestMethod]
-        public void SetFieldObjects_RowObject_UnknownAction_FieldNumbers_NoChangesApplied()
+        public void SetFieldObjects_RowObject_UnknownAction_FieldNumbers_ThrowsArgumentException()
         {
             string fieldNumber = "123";
             List<string> fieldNumbers =
@@ -711,14 +711,7 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             RowObject rowObject = new();
             rowObject.AddFieldObject(new FieldObject(fieldNumber));
 
-            bool initialIsEnabled = rowObject.IsFieldEnabled(fieldNumber);
-            bool initialIsModified = rowObject.IsFieldModified(fieldNumber);
-
-            OptionObjectHelpers.SetFieldObjects(rowObject, "UNKNOWN", fieldNumbers);
-
-            Assert.AreEqual(initialIsEnabled, rowObject.IsFieldEnabled(fieldNumber));
-            Assert.AreEqual(initialIsModified, rowObject.IsFieldModified(fieldNumber));
-            Assert.IsNull(rowObject.RowAction);
+            Assert.ThrowsException<ArgumentException>(() => OptionObjectHelpers.SetFieldObjects(rowObject, "UNKNOWN", fieldNumbers));
         }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/TransformToOptionObject2015Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/TransformToOptionObject2015Tests.cs
@@ -529,5 +529,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             Assert.AreNotEqual(expected.EntityID, actual.EntityID);
             Assert.AreNotEqual(expected, actual);
         }
+
+        [TestMethod]
+        public void TransformToOptionObject2015_OptionObject_WithNullInput_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.TransformToOptionObject2015((OptionObject)null!));
+        }
+
+        [TestMethod]
+        public void TransformToOptionObject2015_OptionObject2_WithNullInput_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.TransformToOptionObject2015((OptionObject2)null!));
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/TransformToOptionObject2Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/TransformToOptionObject2Tests.cs
@@ -524,5 +524,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             Assert.AreNotEqual(expected.EntityID, actual.EntityID);
             Assert.AreNotEqual(expected, actual);
         }
+
+        [TestMethod]
+        public void TransformToOptionObject2_OptionObject_WithNullInput_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.TransformToOptionObject2((OptionObject)null!));
+        }
+
+        [TestMethod]
+        public void TransformToOptionObject2_OptionObject2015_WithNullInput_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.TransformToOptionObject2((OptionObject2015)null!));
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/TransformToOptionObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Tests/Helpers/OptionObject/TransformToOptionObjectTests.cs
@@ -521,5 +521,17 @@ namespace RarelySimple.AvatarScriptLink.Tests.Helpers
             Assert.AreNotEqual(expected.EntityID, actual.EntityID);
             Assert.AreNotEqual(expected, actual);
         }
+
+        [TestMethod]
+        public void TransformToOptionObject_OptionObject2_WithNullInput_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.TransformToOptionObject((OptionObject2)null!));
+        }
+
+        [TestMethod]
+        public void TransformToOptionObject_OptionObject2015_WithNullInput_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.TransformToOptionObject((OptionObject2015)null!));
+        }
     }
 }

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddFieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddFieldObject.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> or <paramref name="fieldObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the field object already exists in the row.</exception>
         /// <returns></returns>
         public static IRowObject AddFieldObject(IRowObject rowObject, IFieldObject fieldObject)
         {
@@ -31,6 +33,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when the field object already exists in the row.</exception>
         /// <returns></returns>
         public static IRowObject AddFieldObject(IRowObject rowObject, string fieldNumber, string fieldValue)
         {
@@ -49,6 +53,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="enabledValue"></param>
         /// <param name="lockedValue"></param>
         /// <param name="requiredValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when the field object already exists in the row.</exception>
         /// <returns></returns>
         public static IRowObject AddFieldObject(IRowObject rowObject, string fieldNumber, string fieldValue, string enabledValue, string lockedValue, string requiredValue)
         {
@@ -70,6 +76,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="enabled"></param>
         /// <param name="locked"></param>
         /// <param name="required"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when the field object already exists in the row.</exception>
         /// <returns></returns>
         public static IRowObject AddFieldObject(IRowObject rowObject, string fieldNumber, string fieldValue, bool enabled, bool locked, bool required)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddFormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddFormObject.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="formObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the form cannot be added due to validation constraints.</exception>
         /// <returns></returns>
         public static IOptionObject AddFormObject(IOptionObject optionObject, IFormObject formObject)
         {
@@ -32,6 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
         /// <param name="multipleIteration"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the created form cannot be added due to validation constraints.</exception>
         /// <returns></returns>
         public static IOptionObject AddFormObject(IOptionObject optionObject, string formId, bool multipleIteration)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddRowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddRowObject.cs
@@ -13,6 +13,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
         /// <param name="rowObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when the option object has no forms.</exception>
         /// <returns></returns>
         public static IOptionObject AddRowObject(IOptionObject optionObject, string formId, IRowObject rowObject)
         {
@@ -39,6 +40,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="rowObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> or <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the row cannot be added due to form constraints or duplicate row IDs.</exception>
         /// <returns></returns>
         public static IFormObject AddRowObject(IFormObject formObject, IRowObject rowObject)
         {
@@ -72,6 +75,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formObject"></param>
         /// <param name="rowId"></param>
         /// <param name="parentRowId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the row cannot be added due to form constraints or duplicate row IDs.</exception>
         /// <returns></returns>
         public static IFormObject AddRowObject(IFormObject formObject, string rowId, string parentRowId)
         {
@@ -86,6 +91,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowId"></param>
         /// <param name="parentRowId"></param>
         /// <param name="rowAction"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the row cannot be added due to form constraints or duplicate row IDs.</exception>
         /// <returns></returns>
         public static IFormObject AddRowObject(IFormObject formObject, string rowId, string parentRowId, string rowAction)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddRowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/AddRowObject.cs
@@ -13,7 +13,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
         /// <param name="rowObject"></param>
-        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when the option object has no forms.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="rowObject"/> is null, when <paramref name="formId"/> is null or empty, or when <paramref name="optionObject"/> has no forms.</exception>
         /// <returns></returns>
         public static IOptionObject AddRowObject(IOptionObject optionObject, string formId, IRowObject rowObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/DeleteRowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/DeleteRowObject.cs
@@ -27,7 +27,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="rowId"></param>
-        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when the option object has no forms.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null, when <paramref name="rowId"/> is null or empty, or when <paramref name="optionObject"/> has no forms.</exception>
         /// <exception cref="ArgumentException">Thrown when a matching row cannot be found for deletion.</exception>
         /// <returns></returns>
         public static IOptionObject DeleteRowObject(IOptionObject optionObject, string rowId)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/DeleteRowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/DeleteRowObject.cs
@@ -13,6 +13,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="rowObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when a matching row cannot be found for deletion.</exception>
         /// <returns></returns>
         public static IOptionObject DeleteRowObject(IOptionObject optionObject, IRowObject rowObject)
         {
@@ -25,6 +27,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="rowId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when the option object has no forms.</exception>
+        /// <exception cref="ArgumentException">Thrown when a matching row cannot be found for deletion.</exception>
         /// <returns></returns>
         public static IOptionObject DeleteRowObject(IOptionObject optionObject, string rowId)
         {
@@ -47,6 +51,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="rowObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when a matching row cannot be found for deletion.</exception>
         /// <returns></returns>
         public static IFormObject DeleteRowObject(IFormObject formObject, IRowObject rowObject)
         {
@@ -59,6 +65,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="rowId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null, or when <paramref name="rowId"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when a matching row cannot be found for deletion.</exception>
         /// <returns></returns>
         public static IFormObject DeleteRowObject(IFormObject formObject, string rowId)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/DisableAllFieldObjects.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/DisableAllFieldObjects.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Sets all <see cref="IFieldObject"/> in the <see cref="IOptionObject"/> to disabled.
         /// </summary>
         /// <param name="optionObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the option object contains no forms.</exception>
         /// <returns></returns>
         public static IOptionObject DisableAllFieldObjects(IOptionObject optionObject)
         {
@@ -24,6 +26,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="excludedFields"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="excludedFields"/> is null, or when the option object has no forms collection.</exception>
+        /// <exception cref="ArgumentException">Thrown when the option object contains no forms.</exception>
         /// <returns></returns>
         public static IOptionObject DisableAllFieldObjects(IOptionObject optionObject, List<string> excludedFields)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetCurrentRowId.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetCurrentRowId.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null, or when <paramref name="formId"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when a matching form cannot be found for <paramref name="formId"/>.</exception>
         /// <returns></returns>
         public static string GetCurrentRowId(IOptionObject optionObject, string formId)
         {
@@ -32,6 +34,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Gets the CurrentRow.RowId of the <see cref="IFormObject"/>.
         /// </summary>
         /// <param name="formObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null, or when it has no current row.</exception>
         /// <returns></returns>
         public static string GetCurrentRowId(IFormObject formObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetFieldValue.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetFieldValue.cs
@@ -15,6 +15,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static string GetFieldValue(IOptionObject optionObject, string fieldNumber)
         {
@@ -34,6 +36,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formId"></param>
         /// <param name="rowId"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when any required argument is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for the provided identifiers.</exception>
         /// <returns></returns>
         public static string GetFieldValue(IOptionObject optionObject, string formId, string rowId, string fieldNumber)
         {
@@ -57,6 +61,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for the provided identifiers.</exception>
         /// <returns></returns>
         public static string GetFieldValue(IFormObject formObject, string fieldNumber)
         {
@@ -68,6 +74,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formObject"></param>
         /// <param name="rowId"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null, or when <paramref name="rowId"/> or <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for the provided identifiers.</exception>
         /// <returns></returns>
         public static string GetFieldValue(IFormObject formObject, string rowId, string fieldNumber)
         {
@@ -91,6 +99,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static string GetFieldValue(IRowObject rowObject, string fieldNumber)
         {
@@ -109,6 +119,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns the FieldValue of a <see cref="IFieldObject"/>.
         /// </summary>
         /// <param name="fieldObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObject"/> is null.</exception>
         /// <returns></returns>
         public static string GetFieldValue(IFieldObject fieldObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetFieldValues.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetFieldValues.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static List<string> GetFieldValues(IOptionObject optionObject, string fieldNumber)
         {
@@ -29,6 +30,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static List<string> GetFieldValues(IFormObject formObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetFormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetFormObject.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null, or when <paramref name="formId"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching <see cref="FormObject"/> exists for the provided <paramref name="formId"/>.</exception>
         /// <returns></returns>
         public static FormObject GetFormObject(IOptionObject optionObject, string formId)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetMultipleIterationStatus.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetMultipleIterationStatus.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null, or when <paramref name="formId"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when a matching form cannot be found for <paramref name="formId"/>.</exception>
         /// <returns></returns>
         public static bool GetMultipleIterationStatus(IOptionObject optionObject, string formId)
         {
@@ -31,6 +33,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns whether a <see cref="IFormObject"/> is Multiple Iteration.
         /// </summary>
         /// <param name="formObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
         /// <returns></returns>
         public static bool GetMultipleIterationStatus(IFormObject formObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetNextAvailableRowId.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetNextAvailableRowId.cs
@@ -10,6 +10,9 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns the next available RowId for an <see cref="IFormObject"/>.
         /// </summary>
         /// <param name="formObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when another row cannot be added due to form constraints.</exception>
+        /// <exception cref="ArgumentException">Thrown when a next available row ID cannot be determined.</exception>
         /// <returns></returns>
         public static string GetNextAvailableRowId(IFormObject formObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetOptionObjectHeaders.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetOptionObjectHeaders.cs
@@ -46,6 +46,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns a List of the <see cref="IOptionObject2015"/> properties and values.
         /// </summary>
         /// <param name="optionObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
         /// <returns></returns>
         public static List<string> GetOptionObjectHeaders(IOptionObject2015 optionObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetParentRowId.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetParentRowId.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null, or when <paramref name="formId"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when a matching form cannot be found for <paramref name="formId"/>.</exception>
         /// <returns></returns>
         public static string GetParentRowId(IOptionObject optionObject, string formId)
         {
@@ -31,6 +33,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns the ParentRowId of a <see cref="IFormObject"/>.
         /// </summary>
         /// <param name="formObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null, or when it has no current row.</exception>
         /// <returns></returns>
         public static string GetParentRowId(IFormObject formObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetReturnOptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/GetReturnOptionObject.cs
@@ -9,6 +9,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <summary>
         /// Used to create the <see cref="IOptionObject"/> for return to myAvatar.
         /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
         /// <returns></returns>
         public static IOptionObject GetReturnOptionObject(IOptionObject optionObject)
         {
@@ -24,6 +25,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="errorCode"></param>
         /// <param name="errorMessage"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="errorCode"/> or <paramref name="errorMessage"/> is invalid.</exception>
         /// <returns></returns>
         public static IOptionObject GetReturnOptionObject(IOptionObject optionObject, double errorCode, string errorMessage)
         {
@@ -37,6 +40,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <summary>
         /// Used to create the <see cref="IOptionObject2"/> for return to myAvatar.
         /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
         /// <returns></returns>
         public static IOptionObject2 GetReturnOptionObject(IOptionObject2 optionObject)
         {
@@ -52,6 +56,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="errorCode"></param>
         /// <param name="errorMessage"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="errorCode"/> or <paramref name="errorMessage"/> is invalid.</exception>
         /// <returns></returns>
         public static IOptionObject2 GetReturnOptionObject(IOptionObject2 optionObject, double errorCode, string errorMessage)
         {
@@ -66,6 +72,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <summary>
         /// Used to create the <see cref="IOptionObject2015"/> for return to myAvatar.
         /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
         /// <returns></returns>
         public static IOptionObject2015 GetReturnOptionObject(IOptionObject2015 optionObject)
         {
@@ -81,6 +88,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="errorCode"></param>
         /// <param name="errorMessage"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="errorCode"/> or <paramref name="errorMessage"/> is invalid.</exception>
         /// <returns></returns>
         public static IOptionObject2015 GetReturnOptionObject(IOptionObject2015 optionObject, double errorCode, string errorMessage)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldEnabled.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldEnabled.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldEnabled(IOptionObject optionObject, string fieldNumber)
         {
@@ -29,6 +31,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> has no current row, or when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFieldEnabled(IFormObject formObject, string fieldNumber)
         {
@@ -43,6 +46,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> has no fields, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldEnabled(IRowObject rowObject, string fieldNumber)
         {
@@ -61,6 +66,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns whether the <see cref="IFieldObject"/> is enabled.
         /// </summary>
         /// <param name="fieldObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObject"/> is null.</exception>
         /// <returns></returns>
         public static bool IsFieldEnabled(IFieldObject fieldObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldLocked.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldLocked.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldLocked(IOptionObject optionObject, string fieldNumber)
         {
@@ -29,6 +31,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> has no current row, or when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFieldLocked(IFormObject formObject, string fieldNumber)
         {
@@ -43,6 +46,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> has no fields, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldLocked(IRowObject rowObject, string fieldNumber)
         {
@@ -61,6 +66,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns whether the <see cref="IFieldObject"/> is locked.
         /// </summary>
         /// <param name="fieldObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObject"/> is null.</exception>
         /// <returns></returns>
         public static bool IsFieldLocked(IFieldObject fieldObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldModified.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldModified.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldModified(IOptionObject optionObject, string fieldNumber)
         {
@@ -29,6 +31,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> has no current row, or when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFieldModified(IFormObject formObject, string fieldNumber)
         {
@@ -43,6 +46,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> has no fields, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldModified(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldPresent.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldPresent.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFieldPresent(IOptionObject optionObject, string fieldNumber)
         {
@@ -24,6 +25,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFieldPresent(IFormObject formObject, string fieldNumber)
         {
@@ -38,6 +40,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFieldPresent(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldRequired.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFieldRequired.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldRequired(IOptionObject optionObject, string fieldNumber)
         {
@@ -29,6 +31,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> has no current row, or when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFieldRequired(IFormObject formObject, string fieldNumber)
         {
@@ -43,6 +46,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> has no fields, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static bool IsFieldRequired(IRowObject rowObject, string fieldNumber)
         {
@@ -61,6 +66,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Returns whether the <see cref="IFieldObject"/> is required.
         /// </summary>
         /// <param name="fieldObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObject"/> is null.</exception>
         /// <returns></returns>
         public static bool IsFieldRequired(IFieldObject fieldObject)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFormPresent.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsFormPresent.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="formId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null, or when <paramref name="formId"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsFormPresent(IOptionObject optionObject, string formId)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsRowMarkedForDeletion.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsRowMarkedForDeletion.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="rowId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowId"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsRowMarkedForDeletion(IOptionObject optionObject, string rowId)
         {
@@ -24,6 +25,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="rowId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> has no current row, or when <paramref name="rowId"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsRowMarkedForDeletion(IFormObject formObject, string rowId)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsRowPresent.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/IsRowPresent.cs
@@ -11,6 +11,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="rowId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> has no forms, or when <paramref name="rowId"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsRowPresent(IOptionObject optionObject, string rowId)
         {
@@ -25,6 +26,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="rowId"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> has no current row, or when <paramref name="rowId"/> is null or empty.</exception>
         /// <returns></returns>
         public static bool IsRowPresent(IFormObject formObject, string rowId)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/RemoveFieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/RemoveFieldObject.cs
@@ -28,7 +28,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null, when <paramref name="fieldNumber"/> is null or empty, or when no matching field exists.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field exists for <paramref name="fieldNumber"/>.</exception>
         /// <returns></returns>
         public static IRowObject RemoveFieldObject(IRowObject rowObject, string fieldNumber)
         {
@@ -38,7 +39,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
                 throw new ArgumentNullException(nameof(fieldNumber), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
             FieldObject fieldObject = rowObject.Fields.Find(f => f.FieldNumber == fieldNumber);
             if (fieldObject == null)
-                throw new ArgumentNullException(nameof(rowObject), ScriptLinkHelpers.GetLocalizedString("noFieldObjectsFoundByFieldNumber", CultureInfo.CurrentCulture) + fieldNumber);
+                throw new ArgumentException(ScriptLinkHelpers.GetLocalizedString("noFieldObjectsFoundByFieldNumber", CultureInfo.CurrentCulture) + fieldNumber, nameof(fieldNumber));
             return RemoveFieldObject(rowObject, fieldObject);
         }
     }

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/RemoveFieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/RemoveFieldObject.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> or <paramref name="fieldObject"/> is null.</exception>
         /// <returns></returns>
         public static IRowObject RemoveFieldObject(IRowObject rowObject, IFieldObject fieldObject)
         {
@@ -27,6 +28,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null, when <paramref name="fieldNumber"/> is null or empty, or when no matching field exists.</exception>
         /// <returns></returns>
         public static IRowObject RemoveFieldObject(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledField.cs
@@ -10,6 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetDisabledField(IOptionObject optionObject, string fieldNumber)
         {
@@ -20,6 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetDisabledField(IFormObject formObject, string fieldNumber)
         {
@@ -30,6 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetDisabledField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledField.cs
@@ -10,8 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetDisabledField(IOptionObject optionObject, string fieldNumber)
         {
@@ -22,8 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetDisabledField(IFormObject formObject, string fieldNumber)
         {
@@ -34,8 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetDisabledField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledFields.cs
@@ -11,8 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetDisabledFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -23,8 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetDisabledFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -35,8 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetDisabledFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -47,8 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetDisabledFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledFields.cs
@@ -11,7 +11,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains one or more null or empty field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetDisabledFields(IOptionObject optionObject, List<FieldObject> fieldObjects)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetDisabledFields.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetDisabledFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -21,6 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetDisabledFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -31,6 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetDisabledFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -41,6 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetDisabledFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledField.cs
@@ -10,8 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetEnabledField(IOptionObject optionObject, string fieldNumber)
         {
@@ -22,8 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetEnabledField(IFormObject formObject, string fieldNumber)
         {
@@ -34,8 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetEnabledField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledField.cs
@@ -10,6 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetEnabledField(IOptionObject optionObject, string fieldNumber)
         {
@@ -20,6 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetEnabledField(IFormObject formObject, string fieldNumber)
         {
@@ -30,6 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetEnabledField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledFields.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetEnabledFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -21,6 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetEnabledFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -31,6 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetEnabledFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -41,6 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetEnabledFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledFields.cs
@@ -11,8 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetEnabledFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -23,8 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetEnabledFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -35,8 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetEnabledFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -47,8 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetEnabledFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetEnabledFields.cs
@@ -11,7 +11,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains one or more null or empty field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetEnabledFields(IOptionObject optionObject, List<FieldObject> fieldObjects)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetErrorCodeAndMessage.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetErrorCodeAndMessage.cs
@@ -13,6 +13,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="errorCode"></param>
         /// <param name="errorMessage"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="errorCode"/> or <paramref name="errorMessage"/> is not valid for the requested operation.</exception>
         /// <returns></returns>
         public static IOptionObject SetErrorCodeAndMessage(IOptionObject optionObject, double errorCode = 0, string errorMessage = "")
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObject.cs
@@ -12,8 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> or <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldObject(IOptionObject optionObject, string fieldAction, string fieldNumber)
         {
@@ -26,8 +26,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> or <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldObject(IFormObject formObject, string fieldAction, string fieldNumber)
         {
@@ -40,8 +40,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> or <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetFieldObject(IRowObject rowObject, string fieldAction, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObject.cs
@@ -12,6 +12,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldObject(IOptionObject optionObject, string fieldAction, string fieldNumber)
         {
@@ -24,6 +26,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldObject(IFormObject formObject, string fieldAction, string fieldNumber)
         {
@@ -36,6 +40,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetFieldObject(IRowObject rowObject, string fieldAction, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObjects.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObjects.cs
@@ -15,11 +15,14 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty, or when <paramref name="fieldObjects"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldObjects(IOptionObject optionObject, string fieldAction, List<FieldObject> fieldObjects)
         {
+            if (fieldObjects == null)
+                throw new ArgumentNullException(nameof(fieldObjects), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+
             List<string> fieldNumbers = GetFieldNumbersToSet(fieldObjects);
             return SetFieldObjects(optionObject, fieldAction, fieldNumbers);
         }
@@ -29,13 +32,15 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty, or when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldObjects(IOptionObject optionObject, string fieldAction, List<string> fieldNumbers)
         {
             if (string.IsNullOrEmpty(fieldAction))
                 throw new ArgumentNullException(nameof(fieldAction), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+            if (fieldNumbers == null)
+                throw new ArgumentNullException(nameof(fieldNumbers), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
 
             List<string> fieldsToSet = new List<string>();
             foreach (string fieldNumber in fieldNumbers.Where(f => IsFieldPresent(optionObject, f)))
@@ -69,13 +74,15 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty, or when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldObjects(IFormObject formObject, string fieldAction, List<string> fieldNumbers)
         {
             if (string.IsNullOrEmpty(fieldAction))
                 throw new ArgumentNullException(nameof(fieldAction), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+            if (fieldNumbers == null)
+                throw new ArgumentNullException(nameof(fieldNumbers), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
 
             List<string> fieldsToSet = new List<string>();
             foreach (string fieldNumber in fieldNumbers.Where(f => IsFieldPresent(formObject, f)))
@@ -102,13 +109,15 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty, or when <paramref name="fieldNumbers"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetFieldObjects(IRowObject rowObject, string fieldAction, List<string> fieldNumbers)
         {
             if (string.IsNullOrEmpty(fieldAction))
                 throw new ArgumentNullException(nameof(fieldAction), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+            if (fieldNumbers == null)
+                throw new ArgumentNullException(nameof(fieldNumbers), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
 
             List<string> fieldsToSet = new List<string>();
             foreach (string fieldNumber in fieldNumbers.Where(f => IsFieldPresent(rowObject, f)))

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObjects.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObjects.cs
@@ -39,6 +39,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         {
             if (string.IsNullOrEmpty(fieldAction))
                 throw new ArgumentNullException(nameof(fieldAction), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+            ValidateFieldAction(fieldAction);
             if (fieldNumbers == null)
                 throw new ArgumentNullException(nameof(fieldNumbers), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
 
@@ -75,12 +76,13 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty, or when <paramref name="fieldNumbers"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldObjects(IFormObject formObject, string fieldAction, List<string> fieldNumbers)
         {
             if (string.IsNullOrEmpty(fieldAction))
                 throw new ArgumentNullException(nameof(fieldAction), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+            ValidateFieldAction(fieldAction);
             if (fieldNumbers == null)
                 throw new ArgumentNullException(nameof(fieldNumbers), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
 
@@ -110,12 +112,13 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty, or when <paramref name="fieldNumbers"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IRowObject SetFieldObjects(IRowObject rowObject, string fieldAction, List<string> fieldNumbers)
         {
             if (string.IsNullOrEmpty(fieldAction))
                 throw new ArgumentNullException(nameof(fieldAction), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+            ValidateFieldAction(fieldAction);
             if (fieldNumbers == null)
                 throw new ArgumentNullException(nameof(fieldNumbers), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
 
@@ -167,6 +170,20 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         }
 
         #region HelperMethods
+        private static void ValidateFieldAction(string fieldAction)
+        {
+            if (fieldAction != FieldAction.Disable &&
+                fieldAction != FieldAction.Enable &&
+                fieldAction != FieldAction.Lock &&
+                fieldAction != FieldAction.Modify &&
+                fieldAction != FieldAction.Optional &&
+                fieldAction != FieldAction.Require &&
+                fieldAction != FieldAction.Unlock)
+            {
+                throw new ArgumentException($"Unsupported fieldAction value: {fieldAction}", nameof(fieldAction));
+            }
+        }
+
         private static List<string> GetFieldNumbersToSet(List<FieldObject> fieldObjects)
         {
             List<string> fieldNumbers = new List<string>();

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObjects.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldObjects.cs
@@ -15,6 +15,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldObjects"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldObjects(IOptionObject optionObject, string fieldAction, List<FieldObject> fieldObjects)
         {
@@ -27,6 +29,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldObjects(IOptionObject optionObject, string fieldAction, List<string> fieldNumbers)
         {
@@ -65,6 +69,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldObjects(IFormObject formObject, string fieldAction, List<string> fieldNumbers)
         {
@@ -96,6 +102,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowObject"></param>
         /// <param name="fieldAction"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldAction"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetFieldObjects(IRowObject rowObject, string fieldAction, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldValue.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldValue.cs
@@ -14,6 +14,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when the field cannot be uniquely identified or no matching field exists.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldValue(IOptionObject optionObject, string fieldNumber, string fieldValue)
         {
@@ -39,6 +41,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowId"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when the option object has no forms.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldValue(IOptionObject optionObject, string formId, string rowId, string fieldNumber, string fieldValue)
         {
@@ -65,6 +68,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> has no current row, or when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when the field cannot be uniquely identified.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldValue(IFormObject formObject, string fieldNumber, string fieldValue)
         {
@@ -83,6 +88,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowId"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when <paramref name="formObject"/> has no current row.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching field can be found for the provided identifiers.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldValue(IFormObject formObject, string rowId, string fieldNumber, string fieldValue)
         {
@@ -118,6 +125,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <returns></returns>
         public static IRowObject SetFieldValue(IRowObject rowObject, string fieldNumber, string fieldValue)
         {
@@ -139,6 +147,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="fieldObject"></param>
         /// <param name="fieldValue"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObject"/> is null.</exception>
         /// <returns></returns>
         public static IFieldObject SetFieldValue(IFieldObject fieldObject, string fieldValue)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldValue.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetFieldValue.cs
@@ -41,7 +41,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowId"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
-        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when the option object has no forms.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null, when <paramref name="formId"/>, <paramref name="rowId"/>, or <paramref name="fieldNumber"/> is null or empty, or when <paramref name="optionObject"/> has no forms.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching form, row, or field is found for the provided identifiers.</exception>
         /// <returns></returns>
         public static IOptionObject SetFieldValue(IOptionObject optionObject, string formId, string rowId, string fieldNumber, string fieldValue)
         {
@@ -88,7 +89,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// <param name="rowId"></param>
         /// <param name="fieldNumber"></param>
         /// <param name="fieldValue"></param>
-        /// <exception cref="ArgumentNullException">Thrown when required arguments are null or empty, or when <paramref name="formObject"/> has no current row.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null or has no current row, or when <paramref name="rowId"/> or <paramref name="fieldNumber"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching field can be found for the provided identifiers.</exception>
         /// <returns></returns>
         public static IFormObject SetFieldValue(IFormObject formObject, string rowId, string fieldNumber, string fieldValue)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedField.cs
@@ -10,6 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetLockedField(IOptionObject optionObject, string fieldNumber)
         {
@@ -20,6 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetLockedField(IFormObject formObject, string fieldNumber)
         {
@@ -30,6 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetLockedField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedField.cs
@@ -10,8 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetLockedField(IOptionObject optionObject, string fieldNumber)
         {
@@ -22,8 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetLockedField(IFormObject formObject, string fieldNumber)
         {
@@ -34,8 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetLockedField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedFields.cs
@@ -11,8 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetLockedFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -23,8 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetLockedFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -35,8 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetLockedFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -47,8 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetLockedFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedFields.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetLockedFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -21,6 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetLockedFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -31,6 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetLockedFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -41,6 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetLockedFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetLockedFields.cs
@@ -11,7 +11,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains one or more null or empty field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetLockedFields(IOptionObject optionObject, List<FieldObject> fieldObjects)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalField.cs
@@ -10,8 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetOptionalField(IOptionObject optionObject, string fieldNumber)
         {
@@ -22,8 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetOptionalField(IFormObject formObject, string fieldNumber)
         {
@@ -34,8 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetOptionalField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalField.cs
@@ -10,6 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetOptionalField(IOptionObject optionObject, string fieldNumber)
         {
@@ -20,6 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetOptionalField(IFormObject formObject, string fieldNumber)
         {
@@ -30,6 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetOptionalField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalFields.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetOptionalFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -21,6 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetOptionalFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -31,6 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetOptionalFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -41,6 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetOptionalFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalFields.cs
@@ -11,7 +11,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains one or more null or empty field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetOptionalFields(IOptionObject optionObject, List<FieldObject> fieldObjects)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetOptionalFields.cs
@@ -11,8 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetOptionalFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -23,8 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetOptionalFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -35,8 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetOptionalFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -47,8 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetOptionalFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredField.cs
@@ -10,6 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetRequiredField(IOptionObject optionObject, string fieldNumber)
         {
@@ -20,6 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetRequiredField(IFormObject formObject, string fieldNumber)
         {
@@ -30,6 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetRequiredField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredField.cs
@@ -10,8 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetRequiredField(IOptionObject optionObject, string fieldNumber)
         {
@@ -22,8 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetRequiredField(IFormObject formObject, string fieldNumber)
         {
@@ -34,8 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetRequiredField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredFields.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetRequiredFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -21,6 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetRequiredFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -31,6 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetRequiredFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -41,6 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetRequiredFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredFields.cs
@@ -11,7 +11,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains one or more null or empty field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetRequiredFields(IOptionObject optionObject, List<FieldObject> fieldObjects)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetRequiredFields.cs
@@ -11,8 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetRequiredFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -23,8 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetRequiredFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -35,8 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetRequiredFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -47,8 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetRequiredFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedField.cs
@@ -10,6 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetUnlockedField(IOptionObject optionObject, string fieldNumber)
         {
@@ -20,6 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetUnlockedField(IFormObject formObject, string fieldNumber)
         {
@@ -30,6 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetUnlockedField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedField.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedField.cs
@@ -10,8 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetUnlockedField(IOptionObject optionObject, string fieldNumber)
         {
@@ -22,8 +22,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetUnlockedField(IFormObject formObject, string fieldNumber)
         {
@@ -34,8 +34,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumber"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumber"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetUnlockedField(IRowObject rowObject, string fieldNumber)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedFields.cs
@@ -11,7 +11,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> is null or contains one or more null or empty field numbers.</exception>
         /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetUnlockedFields(IOptionObject optionObject, List<FieldObject> fieldObjects)

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedFields.cs
@@ -11,8 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldObjects"/> contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetUnlockedFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -23,8 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found or no fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetUnlockedFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -35,8 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetUnlockedFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -47,8 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
-        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
-        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="fieldNumbers"/> is null or contains one or more null or empty field numbers.</exception>
+        /// <exception cref="ArgumentException">Thrown when no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetUnlockedFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedFields.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/SetUnlockedFields.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldObjects"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetUnlockedFields(IOptionObject optionObject, List<FieldObject> fieldObjects)
         {
@@ -21,6 +23,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="optionObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are updated.</exception>
         /// <returns></returns>
         public static IOptionObject SetUnlockedFields(IOptionObject optionObject, List<string> fieldNumbers)
         {
@@ -31,6 +35,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="formObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IFormObject SetUnlockedFields(IFormObject formObject, List<string> fieldNumbers)
         {
@@ -41,6 +47,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <param name="rowObject"></param>
         /// <param name="fieldNumbers"></param>
+        /// <exception cref="ArgumentNullException">Thrown when delegated field action arguments are null.</exception>
+        /// <exception cref="ArgumentException">Thrown when delegated field action validation fails or no matching fields are found.</exception>
         /// <returns></returns>
         public static IRowObject SetUnlockedFields(IRowObject rowObject, List<string> fieldNumbers)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToFieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToFieldObject.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an Xml- or Json-formatted <see cref="String"/> to <see cref="FieldObject"/>.
         /// </summary>
         /// <param name="serializedString">An Xml- or Json-formatted <see cref="System.String"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializedString"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="serializedString"/> is not a compatible serialized field object.</exception>
         /// <returns>A <see cref="FieldObject"/>.</returns>
         public static IFieldObject TransformToFieldObject(string serializedString)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToFormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToFormObject.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an Xml- or Json-formatted <see cref="String"/> to <see cref="FormObject"/>.
         /// </summary>
         /// <param name="serializedString">An Xml- or Json-formatted <see cref="System.String"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializedString"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="serializedString"/> is not a compatible serialized form object.</exception>
         /// <returns>A <see cref="FormObject"/>.</returns>
         public static IFormObject TransformToFormObject(string serializedString)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2"/> to <see cref="IOptionObject"/>.
         /// </summary>
         /// <param name="optionObject2"></param>
+        /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static OptionObject TransformToOptionObject(IOptionObject2 optionObject2)
         {
@@ -36,6 +37,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2015"/> to <see cref="IOptionObject"/>.
         /// </summary>
         /// <param name="optionObject2015"></param>
+        /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static OptionObject TransformToOptionObject(IOptionObject2015 optionObject2015)
         {
@@ -60,6 +62,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms a serialized string to <see cref="IOptionObject"/>.
         /// </summary>
         /// <param name="serializedString"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializedString"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="serializedString"/> is not a compatible serialized option object.</exception>
         /// <returns></returns>
         public static OptionObject TransformToOptionObject(string serializedString)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject.cs
@@ -12,10 +12,14 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2"/> to <see cref="IOptionObject"/>.
         /// </summary>
         /// <param name="optionObject2"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject2"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static OptionObject TransformToOptionObject(IOptionObject2 optionObject2)
         {
+            if (optionObject2 == null)
+                throw new ArgumentNullException(nameof(optionObject2), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+
             if (!IsValidErrorCode(optionObject2.ErrorCode))
                 throw new ArgumentException(ScriptLinkHelpers.GetLocalizedString("errorCodeIsNotValid", CultureInfo.CurrentCulture));
             var optionObject = new OptionObject
@@ -37,10 +41,14 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2015"/> to <see cref="IOptionObject"/>.
         /// </summary>
         /// <param name="optionObject2015"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject2015"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static OptionObject TransformToOptionObject(IOptionObject2015 optionObject2015)
         {
+            if (optionObject2015 == null)
+                throw new ArgumentNullException(nameof(optionObject2015), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+
             if (!IsValidErrorCode(optionObject2015.ErrorCode))
                 throw new ArgumentException(ScriptLinkHelpers.GetLocalizedString("errorCodeIsNotValid", CultureInfo.CurrentCulture));
             var optionObject = new OptionObject

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject"/> to <see cref="IOptionObject2"/>.
         /// </summary>
         /// <param name="optionObject"></param>
+        /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2 TransformToOptionObject2(IOptionObject optionObject)
         {
@@ -36,6 +37,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2015"/> to <see cref="IOptionObject2"/>.
         /// </summary>
         /// <param name="optionObject2015"></param>
+        /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2 TransformToOptionObject2(IOptionObject2015 optionObject2015)
         {
@@ -63,6 +65,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms a serialized string to <see cref="IOptionObject2"/>.
         /// </summary>
         /// <param name="serializedString"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializedString"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="serializedString"/> is not a compatible serialized option object.</exception>
         /// <returns></returns>
         public static IOptionObject2 TransformToOptionObject2(string serializedString)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2.cs
@@ -12,10 +12,14 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject"/> to <see cref="IOptionObject2"/>.
         /// </summary>
         /// <param name="optionObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2 TransformToOptionObject2(IOptionObject optionObject)
         {
+            if (optionObject == null)
+                throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+
             if (!IsValidErrorCode(optionObject.ErrorCode))
                 throw new ArgumentException(ScriptLinkHelpers.GetLocalizedString("errorCodeIsNotValid", CultureInfo.CurrentCulture));
             var optionObject2 = new OptionObject2
@@ -37,10 +41,14 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2015"/> to <see cref="IOptionObject2"/>.
         /// </summary>
         /// <param name="optionObject2015"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject2015"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2 TransformToOptionObject2(IOptionObject2015 optionObject2015)
         {
+            if (optionObject2015 == null)
+                throw new ArgumentNullException(nameof(optionObject2015), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+
             if (!IsValidErrorCode(optionObject2015.ErrorCode))
                 throw new ArgumentException(ScriptLinkHelpers.GetLocalizedString("errorCodeIsNotValid", CultureInfo.CurrentCulture));
             var optionObject2 = new OptionObject2

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2015.cs
@@ -12,10 +12,14 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject"/> to <see cref="IOptionObject2015"/>.
         /// </summary>
         /// <param name="optionObject"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2015 TransformToOptionObject2015(IOptionObject optionObject)
         {
+            if (optionObject == null)
+                throw new ArgumentNullException(nameof(optionObject), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+
             if (!IsValidErrorCode(optionObject.ErrorCode))
                 throw new ArgumentException(ScriptLinkHelpers.GetLocalizedString("errorCodeIsNotValid", CultureInfo.CurrentCulture));
             var optionObject2015 = new OptionObject2015
@@ -37,10 +41,14 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2"/> to <see cref="IOptionObject2015"/>.
         /// </summary>
         /// <param name="optionObject2"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject2"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2015 TransformToOptionObject2015(IOptionObject2 optionObject2)
         {
+            if (optionObject2 == null)
+                throw new ArgumentNullException(nameof(optionObject2), ScriptLinkHelpers.GetLocalizedString(ParameterCannotBeNull, CultureInfo.CurrentCulture));
+
             if (!IsValidErrorCode(optionObject2.ErrorCode))
                 throw new ArgumentException(ScriptLinkHelpers.GetLocalizedString("errorCodeIsNotValid", CultureInfo.CurrentCulture));
             var optionObject2015 = new OptionObject2015

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToOptionObject2015.cs
@@ -12,6 +12,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject"/> to <see cref="IOptionObject2015"/>.
         /// </summary>
         /// <param name="optionObject"></param>
+        /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2015 TransformToOptionObject2015(IOptionObject optionObject)
         {
@@ -36,6 +37,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an <see cref="IOptionObject2"/> to <see cref="IOptionObject2015"/>.
         /// </summary>
         /// <param name="optionObject2"></param>
+        /// <exception cref="ArgumentException">Thrown when the source object contains an invalid error code.</exception>
         /// <returns></returns>
         public static IOptionObject2015 TransformToOptionObject2015(IOptionObject2 optionObject2)
         {
@@ -63,6 +65,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms a serialized string to <see cref="IOptionObject2015"/>.
         /// </summary>
         /// <param name="serializedString"></param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializedString"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="serializedString"/> is not a compatible serialized option object.</exception>
         /// <returns></returns>
         public static IOptionObject2015 TransformToOptionObject2015(string serializedString)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToRowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/OptionObject/Transform/TransformToRowObject.cs
@@ -11,6 +11,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// Transforms an Xml- or Json-formatted <see cref="System.String"/> to <see cref="RowObject"/>.
         /// </summary>
         /// <param name="serializedString">An Xml- or Json-formatted <see cref="System.String"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="serializedString"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="serializedString"/> is not a compatible serialized row object.</exception>
         /// <returns>A <see cref="RowObject"/>.</returns>
         public static IRowObject TransformToRowObject(string serializedString)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/ScriptLink/Serialize/DeserializeObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/ScriptLink/Serialize/DeserializeObject.cs
@@ -32,6 +32,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="json">The Json <see cref="string"/> to deserialize.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="json"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="json"/> cannot be deserialized to the requested type.</exception>
         /// <returns></returns>
         public static T DeserializeObjectFromJsonString<T>(string json)
         {
@@ -52,6 +54,8 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="xml">The Xml <see cref="string"/> to deserialize.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="xml"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="xml"/> cannot be deserialized to the requested type.</exception>
         /// <returns></returns>
         public static T DeserializeObjectFromXmlString<T>(string xml)
         {

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/ScriptLink/Serialize/SerializeObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/ScriptLink/Serialize/SerializeObject.cs
@@ -42,7 +42,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
             }
             catch (Exception ex)
             {
-                throw new ArgumentException(GetLocalizedString("objectCannotBeSerializedJson", CultureInfo.CurrentCulture), ex.InnerException);
+                throw new ArgumentException(GetLocalizedString("objectCannotBeSerializedJson", CultureInfo.CurrentCulture), ex);
             }
         }
         /// <summary>
@@ -65,7 +65,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
             }
             catch (Exception ex)
             {
-                throw new ArgumentException(GetLocalizedString("objectCannotBeSerializedXmlOrJson", CultureInfo.CurrentCulture), ex.InnerException);
+                throw new ArgumentException(GetLocalizedString("objectCannotBeSerializedXmlOrJson", CultureInfo.CurrentCulture), ex);
             }
         }
     }

--- a/dotnet/RarelySimple.AvatarScriptLink/Helpers/ScriptLink/Serialize/SerializeObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink/Helpers/ScriptLink/Serialize/SerializeObject.cs
@@ -14,6 +14,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="objectToSerialize">The object to be serialized.</param>
+        /// <exception cref="ArgumentException">Thrown when the object cannot be serialized.</exception>
         /// <returns></returns>
         public static string SerializeObject<T>(T objectToSerialize)
         {
@@ -31,6 +32,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="objectToSerialize">The object to be serialized.</param>
+        /// <exception cref="ArgumentException">Thrown when the object cannot be serialized to JSON.</exception>
         /// <returns></returns>
         public static string SerializeObjectToJsonString<T>(T objectToSerialize)
         {
@@ -48,6 +50,7 @@ namespace RarelySimple.AvatarScriptLink.Helpers
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="objectToSerialize">The object to be serialized.</param>
+        /// <exception cref="ArgumentException">Thrown when the object cannot be serialized to XML.</exception>
         /// <returns></returns>
         public static string SerializeObjectToXmlString<T>(T objectToSerialize)
         {


### PR DESCRIPTION
- Added exception documentation for null or invalid arguments in SetEnabledField, SetEnabledFields, SetErrorCodeAndMessage, SetFieldObject, SetFieldObjects, SetFieldValue, SetLockedField, SetLockedFields, SetOptionalField, SetOptionalFields, SetRequiredField, SetRequiredFields, SetUnlockedField, SetUnlockedFields, and Transform methods.
- Improved clarity on potential exceptions thrown during method execution, including ArgumentNullException and ArgumentException.