### PR TITLE
Refactor response builders and add response finalization helpers

### DIFF
--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders.Tests/ResponseBuilderMethodsTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders.Tests/ResponseBuilderMethodsTests.cs
@@ -119,6 +119,554 @@ namespace RarelySimple.AvatarScriptLink.Objects.Builders.Tests
             Assert.AreSame(form, response.Forms[0]);
             Assert.IsTrue(form.MultipleIteration);
         }
+
+        [TestMethod]
+        public void ToReturnOptionObject_RemovesRowsWithoutValidAction_AndPreservesValidRows()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var form = FormObjectBuilders.CreateFormObject("FORM1");
+            form.WithCurrentRow(RowObjectBuilders.CreateRowObject("FORM1||1"));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM1||2").WithRowAction(RowObject.RowActions.Edit));
+            response.AddForm(form);
+
+            // Act
+            OptionObject finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms.Count);
+            Assert.IsNull(finalized.Forms[0].CurrentRow);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows.Count);
+            Assert.AreEqual(RowObject.RowActions.Edit, finalized.Forms[0].OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_DoesNotMutateSourceObject()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var form = FormObjectBuilders.CreateFormObject("FORM1");
+            form.WithCurrentRow(RowObjectBuilders.CreateRowObject("FORM1||1"));
+            response.AddForm(form);
+
+            // Act
+            OptionObject finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.IsNotNull(response.Forms[0].CurrentRow);
+            Assert.AreEqual(0, finalized.Forms.Count);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithErrorDetails_SetsErrorFieldsOnReturnPayload()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+
+            // Act
+            OptionObject finalized = response.ToReturnOptionObject(4, "Error message");
+
+            // Assert
+            Assert.AreEqual(4d, finalized.ErrorCode);
+            Assert.AreEqual("Error message", finalized.ErrorMesg);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2_RemovesFormsWithoutReturnRows()
+        {
+            // Arrange
+            var response = OptionObject2Builders.CreateOptionObject2("Patient456");
+            var form = FormObjectBuilders.CreateFormObject("FORM2");
+            form.WithCurrentRow(RowObjectBuilders.CreateRowObject("FORM2||1"));
+            response.AddForm(form);
+
+            // Act
+            OptionObject2 finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(0, finalized.Forms.Count);
+            Assert.AreEqual(1, response.Forms.Count);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2015_WithErrorDetails_PreservesSessionToken()
+        {
+            // Arrange
+            var response = OptionObject2015Builders.CreateOptionObject2015("Patient789")
+                .WithSessionToken("SESSION-123");
+
+            // Act
+            OptionObject2015 finalized = response.ToReturnOptionObject(2, "Validation error");
+
+            // Assert
+            Assert.AreEqual("SESSION-123", finalized.SessionToken);
+            Assert.AreEqual(2d, finalized.ErrorCode);
+            Assert.AreEqual("Validation error", finalized.ErrorMesg);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_Null_ThrowsArgumentNullException()
+        {
+            // Arrange
+            OptionObject? response = null;
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentNullException>(() => response.ToReturnOptionObject());
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2_Null_ThrowsArgumentNullException()
+        {
+            // Arrange
+            OptionObject2? response = null;
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentNullException>(() => response.ToReturnOptionObject());
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2015_Null_ThrowsArgumentNullException()
+        {
+            // Arrange
+            OptionObject2015? response = null;
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentNullException>(() => response.ToReturnOptionObject());
+        }
+
+        [TestMethod]
+        public void GetReturnOptionObject_Alias_MatchesToReturnOptionObjectBehavior()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var form = FormObjectBuilders.CreateFormObject("FORM1");
+            form.WithCurrentRow(RowObjectBuilders.CreateRowObject("FORM1||1"));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM1||2").WithRowAction(RowObject.RowActions.Delete));
+            response.AddForm(form);
+
+            // Act
+            OptionObject finalizedByAlias = response.GetReturnOptionObject();
+            OptionObject finalizedByPrimary = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(finalizedByPrimary.Forms.Count, finalizedByAlias.Forms.Count);
+            Assert.AreEqual(finalizedByPrimary.Forms[0].OtherRows.Count, finalizedByAlias.Forms[0].OtherRows.Count);
+            Assert.AreEqual(finalizedByPrimary.Forms[0].OtherRows[0].RowAction, finalizedByAlias.Forms[0].OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
+        public void GetReturnOptionObject_WithErrorDetails_Alias_MatchesPrimaryBehavior()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+
+            // Act
+            OptionObject finalizedByAlias = response.GetReturnOptionObject(6, "Open form text");
+            OptionObject finalizedByPrimary = response.ToReturnOptionObject(6, "Open form text");
+
+            // Assert
+            Assert.AreEqual(finalizedByPrimary.ErrorCode, finalizedByAlias.ErrorCode);
+            Assert.AreEqual(finalizedByPrimary.ErrorMesg, finalizedByAlias.ErrorMesg);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_RemovesNullFormsAndNullRows()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+
+            var formWithNullCurrentRow = FormObjectBuilders.CreateFormObject("FORM1");
+            formWithNullCurrentRow.WithCurrentRow(null);
+            formWithNullCurrentRow.AddRow(null);
+            formWithNullCurrentRow.AddRow(RowObjectBuilders.CreateRowObject("FORM1||2").WithRowAction(RowObject.RowActions.Add));
+
+            response.Forms.Add(null);
+            response.AddForm(formWithNullCurrentRow);
+
+            // Act
+            OptionObject finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms.Count);
+            Assert.IsNotNull(finalized.Forms[0]);
+            Assert.IsNull(finalized.Forms[0].CurrentRow);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows.Count);
+            Assert.AreEqual(RowObject.RowActions.Add, finalized.Forms[0].OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_MixedRowActions_PreservesAddEditDeleteOnly()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var form = FormObjectBuilders.CreateFormObject("FORM1");
+            form.WithCurrentRow(RowObjectBuilders.CreateRowObject("FORM1||1").WithRowAction("INVALID"));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM1||2").WithRowAction(RowObject.RowActions.Add));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM1||3").WithRowAction(RowObject.RowActions.Edit));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM1||4").WithRowAction(RowObject.RowActions.Delete));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM1||5"));
+            response.AddForm(form);
+
+            // Act
+            OptionObject finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms.Count);
+            Assert.IsNull(finalized.Forms[0].CurrentRow);
+            Assert.AreEqual(3, finalized.Forms[0].OtherRows.Count);
+            CollectionAssert.AreEquivalent(
+                new[] { RowObject.RowActions.Add, RowObject.RowActions.Edit, RowObject.RowActions.Delete },
+                new[]
+                {
+                    finalized.Forms[0].OtherRows[0].RowAction,
+                    finalized.Forms[0].OtherRows[1].RowAction,
+                    finalized.Forms[0].OtherRows[2].RowAction
+                });
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_PreservesOptionMetadataOnClone()
+        {
+            // Arrange
+            var response = OptionObjectBuilders.CreateOptionObject("Patient123");
+            response.EpisodeNumber = 12;
+            response.Facility = "FAC";
+            response.OptionId = "OPT-1";
+            response.OptionStaffId = "STAFF-1";
+            response.OptionUserId = "USER-1";
+            response.SystemCode = "UAT";
+
+            var form = FormObjectBuilders.CreateFormObject("FORM1");
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM1||2").WithRowAction(RowObject.RowActions.Edit));
+            response.AddForm(form);
+
+            // Act
+            OptionObject finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(response.EntityID, finalized.EntityID);
+            Assert.AreEqual(response.EpisodeNumber, finalized.EpisodeNumber);
+            Assert.AreEqual(response.Facility, finalized.Facility);
+            Assert.AreEqual(response.OptionId, finalized.OptionId);
+            Assert.AreEqual(response.OptionStaffId, finalized.OptionStaffId);
+            Assert.AreEqual(response.OptionUserId, finalized.OptionUserId);
+            Assert.AreEqual(response.SystemCode, finalized.SystemCode);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2_MixedRows_PrunesInvalidAndPreservesValid()
+        {
+            // Arrange
+            var response = OptionObject2Builders.CreateOptionObject2("Patient456");
+            var form = FormObjectBuilders.CreateFormObject("FORM2");
+            form.WithCurrentRow(RowObjectBuilders.CreateRowObject("FORM2||1").WithRowAction(RowObject.RowActions.Edit));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM2||2"));
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM2||3").WithRowAction(RowObject.RowActions.Delete));
+            response.AddForm(form);
+
+            // Act
+            OptionObject2 finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms.Count);
+            Assert.IsNotNull(finalized.Forms[0].CurrentRow);
+            Assert.AreEqual(RowObject.RowActions.Edit, finalized.Forms[0].CurrentRow.RowAction);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows.Count);
+            Assert.AreEqual(RowObject.RowActions.Delete, finalized.Forms[0].OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2015_Preserves2015SpecificMetadata()
+        {
+            // Arrange
+            var response = OptionObject2015Builders.CreateOptionObject2015("Patient789")
+                .WithSessionToken("SESSION-XYZ")
+                .WithOptionUserId("USER-XYZ")
+                .WithEntityId("Patient789");
+            response.NamespaceName = "NS";
+            response.ParentNamespace = "PNS";
+            response.ServerName = "SRV";
+
+            var form = FormObjectBuilders.CreateFormObject("FORM2015");
+            form.AddRow(RowObjectBuilders.CreateRowObject("FORM2015||1").WithRowAction(RowObject.RowActions.Add));
+            response.AddForm(form);
+
+            // Act
+            OptionObject2015 finalized = response.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual("SESSION-XYZ", finalized.SessionToken);
+            Assert.AreEqual("USER-XYZ", finalized.OptionUserId);
+            Assert.AreEqual("NS", finalized.NamespaceName);
+            Assert.AreEqual("PNS", finalized.ParentNamespace);
+            Assert.AreEqual("SRV", finalized.ServerName);
+            Assert.AreEqual(1, finalized.Forms.Count);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithBaseline_PrunesUnchangedEditFields()
+        {
+            // Arrange
+            var baseline = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM1");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            baseline.AddForm(baselineForm);
+
+            var working = baseline.Clone();
+            working.Forms[0].OtherRows[0].Fields[1].FieldValue = "B-CHANGED";
+
+            // Act
+            OptionObject finalized = working.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms.Count);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual("200", finalized.Forms[0].OtherRows[0].Fields[0].FieldNumber);
+            Assert.AreEqual("B-CHANGED", finalized.Forms[0].OtherRows[0].Fields[0].FieldValue);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithoutBaseline_DoesNotPruneEditFields()
+        {
+            // Arrange
+            var working = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var form = FormObjectBuilders.CreateFormObject("FORM1");
+            form.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            working.AddForm(form);
+
+            // Act
+            OptionObject finalized = working.ToReturnOptionObject();
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms.Count);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows.Count);
+            Assert.AreEqual(2, finalized.Forms[0].OtherRows[0].Fields.Count);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithBaselineNull_FallsBackToNoBaselineBehavior()
+        {
+            // Arrange
+            var working = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var form = FormObjectBuilders.CreateFormObject("FORM1");
+            form.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            working.AddForm(form);
+
+            // Act
+            OptionObject? baseline = null;
+            OptionObject finalized = working.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(2, finalized.Forms[0].OtherRows[0].Fields.Count);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithBaseline_PreservesAddAndDeleteRowsWithoutFieldPruning()
+        {
+            // Arrange
+            var baseline = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM1");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A")));
+            baseline.AddForm(baselineForm);
+
+            var working = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var workingForm = FormObjectBuilders.CreateFormObject("FORM1");
+            workingForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||2")
+                    .WithRowAction(RowObject.RowActions.Add)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("300").WithFieldValue("NEW"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("301").WithFieldValue("NEW2")));
+            workingForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||3")
+                    .WithRowAction(RowObject.RowActions.Delete)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("400").WithFieldValue("OLD")));
+            working.AddForm(workingForm);
+
+            // Act
+            OptionObject finalized = working.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(2, finalized.Forms[0].OtherRows.Count);
+            Assert.AreEqual(RowObject.RowActions.Add, finalized.Forms[0].OtherRows[0].RowAction);
+            Assert.AreEqual(2, finalized.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual(RowObject.RowActions.Delete, finalized.Forms[0].OtherRows[1].RowAction);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows[1].Fields.Count);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2_WithBaseline_PrunesUnchangedEditFields()
+        {
+            // Arrange
+            var baseline = OptionObject2Builders.CreateOptionObject2("Patient456");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM2");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM2||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            baseline.AddForm(baselineForm);
+
+            var working = baseline.Clone();
+            working.Forms[0].OtherRows[0].Fields[0].FieldValue = "A-CHANGED";
+
+            // Act
+            OptionObject2 finalized = working.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual("100", finalized.Forms[0].OtherRows[0].Fields[0].FieldNumber);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject2015_WithBaseline_PrunesUnchangedEditFields()
+        {
+            // Arrange
+            var baseline = OptionObject2015Builders.CreateOptionObject2015("Patient789")
+                .WithSessionToken("SESSION");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM2015");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM2015||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            baseline.AddForm(baselineForm);
+
+            var working = baseline.Clone();
+            working.Forms[0].OtherRows[0].Fields[1].Required = FieldObject.RequiredStatus.Required;
+
+            // Act
+            OptionObject2015 finalized = working.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual("200", finalized.Forms[0].OtherRows[0].Fields[0].FieldNumber);
+            Assert.AreEqual(FieldObject.RequiredStatus.Required, finalized.Forms[0].OtherRows[0].Fields[0].Required);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithBaseline_RepeatedCalls_ProducesDeterministicPayload()
+        {
+            // Arrange
+            var baseline = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM1");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            baseline.AddForm(baselineForm);
+
+            var working = baseline.Clone();
+            working.Forms[0].OtherRows[0].Fields[1].FieldValue = "B-UPDATED";
+
+            // Act
+            OptionObject first = working.ToReturnOptionObject(baseline);
+            OptionObject second = working.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(1, first.Forms.Count);
+            Assert.AreEqual(1, second.Forms.Count);
+            Assert.AreEqual(1, first.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, second.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, first.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual(1, second.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual(first.Forms[0].OtherRows[0].Fields[0].FieldNumber, second.Forms[0].OtherRows[0].Fields[0].FieldNumber);
+            Assert.AreEqual(first.Forms[0].OtherRows[0].Fields[0].FieldValue, second.Forms[0].OtherRows[0].Fields[0].FieldValue);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithBaseline_ClonePath_ProducesDeterministicPayload()
+        {
+            // Arrange
+            var baseline = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM1");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            baseline.AddForm(baselineForm);
+
+            var working = baseline.Clone();
+            working.Forms[0].OtherRows[0].Fields[0].Enabled = FieldObject.EnabledStatus.Disabled;
+            var workingClone = working.Clone();
+
+            // Act
+            OptionObject fromWorking = working.ToReturnOptionObject(baseline);
+            OptionObject fromWorkingClone = workingClone.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(1, fromWorking.Forms.Count);
+            Assert.AreEqual(1, fromWorkingClone.Forms.Count);
+            Assert.AreEqual(1, fromWorking.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, fromWorkingClone.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, fromWorking.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual(1, fromWorkingClone.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual(fromWorking.Forms[0].OtherRows[0].Fields[0].FieldNumber, fromWorkingClone.Forms[0].OtherRows[0].Fields[0].FieldNumber);
+            Assert.AreEqual(fromWorking.Forms[0].OtherRows[0].Fields[0].Enabled, fromWorkingClone.Forms[0].OtherRows[0].Fields[0].Enabled);
+        }
+
+        [TestMethod]
+        public void ToReturnOptionObject_WithBaseline_BuilderEquivalentInputs_ProduceDeterministicPayload()
+        {
+            // Arrange
+            var baseline = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM1");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B")));
+            baseline.AddForm(baselineForm);
+
+            var workingA = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var formA = FormObjectBuilders.CreateFormObject("FORM1");
+            formA.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B-UPDATED")));
+            workingA.AddForm(formA);
+
+            var workingB = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var formB = FormObjectBuilders.CreateFormObject("FORM1");
+            formB.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A"))
+                    .AddField(FieldObjectBuilders.CreateFieldObject("200").WithFieldValue("B-UPDATED")));
+            workingB.AddForm(formB);
+
+            // Act
+            OptionObject finalizedA = workingA.ToReturnOptionObject(baseline);
+            OptionObject finalizedB = workingB.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(1, finalizedA.Forms.Count);
+            Assert.AreEqual(1, finalizedB.Forms.Count);
+            Assert.AreEqual(1, finalizedA.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, finalizedB.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, finalizedA.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual(1, finalizedB.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual(finalizedA.Forms[0].OtherRows[0].Fields[0].FieldNumber, finalizedB.Forms[0].OtherRows[0].Fields[0].FieldNumber);
+            Assert.AreEqual(finalizedA.Forms[0].OtherRows[0].Fields[0].FieldValue, finalizedB.Forms[0].OtherRows[0].Fields[0].FieldValue);
+        }
     }
 
     [TestClass]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders.Tests/ResponseBuilderMethodsTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders.Tests/ResponseBuilderMethodsTests.cs
@@ -510,6 +510,32 @@ namespace RarelySimple.AvatarScriptLink.Objects.Builders.Tests
         }
 
         [TestMethod]
+        public void ToReturnOptionObject_WithBaseline_MissingIdentifiers_DoesNotPruneFields()
+        {
+            // Arrange
+            var baseline = OptionObjectBuilders.CreateOptionObject("Patient123");
+            var baselineForm = FormObjectBuilders.CreateFormObject("FORM1");
+            baselineForm.AddRow(
+                RowObjectBuilders.CreateRowObject("FORM1||1")
+                    .WithRowAction(RowObject.RowActions.Edit)
+                    .AddField(FieldObjectBuilders.CreateFieldObject("100").WithFieldValue("A")));
+            baselineForm.FormId = null;
+            baselineForm.OtherRows[0].RowId = null;
+            baseline.AddForm(baselineForm);
+
+            var working = baseline.Clone();
+
+            // Act
+            OptionObject finalized = working.ToReturnOptionObject(baseline);
+
+            // Assert
+            Assert.AreEqual(1, finalized.Forms.Count);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows.Count);
+            Assert.AreEqual(1, finalized.Forms[0].OtherRows[0].Fields.Count);
+            Assert.AreEqual("100", finalized.Forms[0].OtherRows[0].Fields[0].FieldNumber);
+        }
+
+        [TestMethod]
         public void ToReturnOptionObject2_WithBaseline_PrunesUnchangedEditFields()
         {
             // Arrange

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/OptionObject2015ResponseBuilders.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/OptionObject2015ResponseBuilders.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
 {
     /// <summary>
@@ -5,6 +7,123 @@ namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
     /// </summary>
     public static class OptionObject2015ResponseBuilders
     {
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2015"/> by cloning and removing unedited rows.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 ToReturnOptionObject(this OptionObject2015 optionObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            var returnOptionObject = optionObject.Clone();
+            ResponseFinalizationHelpers.RemoveUneditedRows(returnOptionObject.Forms);
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2015"/> by cloning, removing unedited rows, and setting error details.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 ToReturnOptionObject(this OptionObject2015 optionObject, double errorCode, string errorMessage)
+        {
+            var returnOptionObject = optionObject.ToReturnOptionObject();
+            returnOptionObject.ErrorCode = errorCode;
+            returnOptionObject.ErrorMesg = errorMessage ?? string.Empty;
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 ToReturnOptionObject(this OptionObject2015 optionObject, OptionObject2015 baselineOptionObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (baselineOptionObject == null)
+            {
+                return optionObject.ToReturnOptionObject();
+            }
+
+            var returnOptionObject = optionObject.Clone();
+            ResponseFinalizationHelpers.RemoveUneditedRows(returnOptionObject.Forms, baselineOptionObject.Forms);
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object, then applies error details.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 ToReturnOptionObject(this OptionObject2015 optionObject, OptionObject2015 baselineOptionObject, double errorCode, string errorMessage)
+        {
+            var returnOptionObject = optionObject.ToReturnOptionObject(baselineOptionObject);
+            returnOptionObject.ErrorCode = errorCode;
+            returnOptionObject.ErrorMesg = errorMessage ?? string.Empty;
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2015"/> by cloning and removing unedited rows.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 GetReturnOptionObject(this OptionObject2015 optionObject)
+        {
+            return optionObject.ToReturnOptionObject();
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2015"/> by cloning, removing unedited rows, and setting error details.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 GetReturnOptionObject(this OptionObject2015 optionObject, double errorCode, string errorMessage)
+        {
+            return optionObject.ToReturnOptionObject(errorCode, errorMessage);
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 GetReturnOptionObject(this OptionObject2015 optionObject, OptionObject2015 baselineOptionObject)
+        {
+            return optionObject.ToReturnOptionObject(baselineOptionObject);
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object, then applies error details.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2015 GetReturnOptionObject(this OptionObject2015 optionObject, OptionObject2015 baselineOptionObject, double errorCode, string errorMessage)
+        {
+            return optionObject.ToReturnOptionObject(baselineOptionObject, errorCode, errorMessage);
+        }
+
         /// <summary>
         /// Creates a success response <see cref="OptionObject2015"/> with the specified entity ID.
         /// </summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/OptionObject2ResponseBuilders.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/OptionObject2ResponseBuilders.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
 {
     /// <summary>
@@ -5,6 +7,123 @@ namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
     /// </summary>
     public static class OptionObject2ResponseBuilders
     {
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2"/> by cloning and removing unedited rows.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 ToReturnOptionObject(this OptionObject2 optionObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            var returnOptionObject = optionObject.Clone();
+            ResponseFinalizationHelpers.RemoveUneditedRows(returnOptionObject.Forms);
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2"/> by cloning, removing unedited rows, and setting error details.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 ToReturnOptionObject(this OptionObject2 optionObject, double errorCode, string errorMessage)
+        {
+            var returnOptionObject = optionObject.ToReturnOptionObject();
+            returnOptionObject.ErrorCode = errorCode;
+            returnOptionObject.ErrorMesg = errorMessage ?? string.Empty;
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 ToReturnOptionObject(this OptionObject2 optionObject, OptionObject2 baselineOptionObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (baselineOptionObject == null)
+            {
+                return optionObject.ToReturnOptionObject();
+            }
+
+            var returnOptionObject = optionObject.Clone();
+            ResponseFinalizationHelpers.RemoveUneditedRows(returnOptionObject.Forms, baselineOptionObject.Forms);
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object, then applies error details.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 ToReturnOptionObject(this OptionObject2 optionObject, OptionObject2 baselineOptionObject, double errorCode, string errorMessage)
+        {
+            var returnOptionObject = optionObject.ToReturnOptionObject(baselineOptionObject);
+            returnOptionObject.ErrorCode = errorCode;
+            returnOptionObject.ErrorMesg = errorMessage ?? string.Empty;
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2"/> by cloning and removing unedited rows.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 GetReturnOptionObject(this OptionObject2 optionObject)
+        {
+            return optionObject.ToReturnOptionObject();
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject2"/> by cloning, removing unedited rows, and setting error details.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 GetReturnOptionObject(this OptionObject2 optionObject, double errorCode, string errorMessage)
+        {
+            return optionObject.ToReturnOptionObject(errorCode, errorMessage);
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 GetReturnOptionObject(this OptionObject2 optionObject, OptionObject2 baselineOptionObject)
+        {
+            return optionObject.ToReturnOptionObject(baselineOptionObject);
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object, then applies error details.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject2 GetReturnOptionObject(this OptionObject2 optionObject, OptionObject2 baselineOptionObject, double errorCode, string errorMessage)
+        {
+            return optionObject.ToReturnOptionObject(baselineOptionObject, errorCode, errorMessage);
+        }
+
         /// <summary>
         /// Creates a success response <see cref="OptionObject2"/> with the specified entity ID.
         /// </summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/OptionObjectResponseBuilders.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/OptionObjectResponseBuilders.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
 {
     /// <summary>
@@ -5,6 +7,123 @@ namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
     /// </summary>
     public static class OptionObjectResponseBuilders
     {
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject"/> by cloning and removing unedited rows.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject ToReturnOptionObject(this OptionObject optionObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            var returnOptionObject = optionObject.Clone();
+            ResponseFinalizationHelpers.RemoveUneditedRows(returnOptionObject.Forms);
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject"/> by cloning, removing unedited rows, and setting error details.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject ToReturnOptionObject(this OptionObject optionObject, double errorCode, string errorMessage)
+        {
+            var returnOptionObject = optionObject.ToReturnOptionObject();
+            returnOptionObject.ErrorCode = errorCode;
+            returnOptionObject.ErrorMesg = errorMessage ?? string.Empty;
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject ToReturnOptionObject(this OptionObject optionObject, OptionObject baselineOptionObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (baselineOptionObject == null)
+            {
+                return optionObject.ToReturnOptionObject();
+            }
+
+            var returnOptionObject = optionObject.Clone();
+            ResponseFinalizationHelpers.RemoveUneditedRows(returnOptionObject.Forms, baselineOptionObject.Forms);
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object, then applies error details.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject ToReturnOptionObject(this OptionObject optionObject, OptionObject baselineOptionObject, double errorCode, string errorMessage)
+        {
+            var returnOptionObject = optionObject.ToReturnOptionObject(baselineOptionObject);
+            returnOptionObject.ErrorCode = errorCode;
+            returnOptionObject.ErrorMesg = errorMessage ?? string.Empty;
+            return returnOptionObject;
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject"/> by cloning and removing unedited rows.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject GetReturnOptionObject(this OptionObject optionObject)
+        {
+            return optionObject.ToReturnOptionObject();
+        }
+
+        /// <summary>
+        /// Creates a return payload from the source <see cref="OptionObject"/> by cloning, removing unedited rows, and setting error details.
+        /// </summary>
+        /// <param name="optionObject">The source option object.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject GetReturnOptionObject(this OptionObject optionObject, double errorCode, string errorMessage)
+        {
+            return optionObject.ToReturnOptionObject(errorCode, errorMessage);
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject GetReturnOptionObject(this OptionObject optionObject, OptionObject baselineOptionObject)
+        {
+            return optionObject.ToReturnOptionObject(baselineOptionObject);
+        }
+
+        /// <summary>
+        /// Creates a return payload by cloning and pruning against a baseline request object, then applies error details.
+        /// </summary>
+        /// <param name="optionObject">The working option object.</param>
+        /// <param name="baselineOptionObject">The original request option object used as baseline.</param>
+        /// <param name="errorCode">The error code to set on the return payload.</param>
+        /// <param name="errorMessage">The error message to set on the return payload.</param>
+        /// <returns>A finalized return payload.</returns>
+        public static OptionObject GetReturnOptionObject(this OptionObject optionObject, OptionObject baselineOptionObject, double errorCode, string errorMessage)
+        {
+            return optionObject.ToReturnOptionObject(baselineOptionObject, errorCode, errorMessage);
+        }
+
         /// <summary>
         /// Creates a success response <see cref="OptionObject"/> with the specified entity ID.
         /// </summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/ResponseFinalizationHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/ResponseFinalizationHelpers.cs
@@ -1,0 +1,231 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
+{
+    internal static class ResponseFinalizationHelpers
+    {
+        internal static void RemoveUneditedRows(List<FormObject> forms)
+        {
+            if (forms == null)
+            {
+                return;
+            }
+
+            for (int i = forms.Count - 1; i >= 0; i--)
+            {
+                var formObject = forms[i];
+                if (formObject == null)
+                {
+                    forms.RemoveAt(i);
+                    continue;
+                }
+
+                RemoveUneditedRows(formObject);
+
+                if (formObject.CurrentRow == null && (formObject.OtherRows == null || formObject.OtherRows.Count == 0))
+                {
+                    forms.RemoveAt(i);
+                }
+            }
+        }
+
+        internal static void RemoveUneditedRows(List<FormObject> forms, List<FormObject> baselineForms)
+        {
+            if (forms == null)
+            {
+                return;
+            }
+
+            if (baselineForms == null)
+            {
+                RemoveUneditedRows(forms);
+                return;
+            }
+
+            var baselineFieldMap = BuildBaselineFieldMap(baselineForms);
+
+            for (int i = forms.Count - 1; i >= 0; i--)
+            {
+                var formObject = forms[i];
+                if (formObject == null)
+                {
+                    forms.RemoveAt(i);
+                    continue;
+                }
+
+                RemoveUneditedRows(formObject, baselineFieldMap);
+
+                if (formObject.CurrentRow == null && (formObject.OtherRows == null || formObject.OtherRows.Count == 0))
+                {
+                    forms.RemoveAt(i);
+                }
+            }
+        }
+
+        private static void RemoveUneditedRows(FormObject formObject)
+        {
+            if (formObject.CurrentRow != null && !IsValidRowAction(formObject.CurrentRow.RowAction))
+            {
+                formObject.CurrentRow = null;
+            }
+
+            if (formObject.OtherRows == null)
+            {
+                formObject.OtherRows = new List<RowObject>();
+                return;
+            }
+
+            for (int i = formObject.OtherRows.Count - 1; i >= 0; i--)
+            {
+                var rowObject = formObject.OtherRows[i];
+                if (rowObject == null || !IsValidRowAction(rowObject.RowAction))
+                {
+                    formObject.OtherRows.RemoveAt(i);
+                }
+            }
+        }
+
+        private static void RemoveUneditedRows(FormObject formObject, Dictionary<string, BaselineFieldSnapshot> baselineFieldMap)
+        {
+            if (ShouldRemoveRow(formObject.FormId, formObject.CurrentRow, baselineFieldMap))
+            {
+                formObject.CurrentRow = null;
+            }
+
+            if (formObject.OtherRows == null)
+            {
+                formObject.OtherRows = new List<RowObject>();
+                return;
+            }
+
+            for (int i = formObject.OtherRows.Count - 1; i >= 0; i--)
+            {
+                var rowObject = formObject.OtherRows[i];
+                if (ShouldRemoveRow(formObject.FormId, rowObject, baselineFieldMap))
+                {
+                    formObject.OtherRows.RemoveAt(i);
+                }
+            }
+        }
+
+        private static bool ShouldRemoveRow(string formId, RowObject rowObject, Dictionary<string, BaselineFieldSnapshot> baselineFieldMap)
+        {
+            if (rowObject == null || !IsValidRowAction(rowObject.RowAction))
+            {
+                return true;
+            }
+
+            if (rowObject.RowAction != RowObject.RowActions.Edit)
+            {
+                return false;
+            }
+
+            PruneUnchangedFields(formId, rowObject, baselineFieldMap);
+            return !rowObject.HasFields();
+        }
+
+        private static void PruneUnchangedFields(string formId, RowObject rowObject, Dictionary<string, BaselineFieldSnapshot> baselineFieldMap)
+        {
+            if (rowObject.Fields == null)
+            {
+                rowObject.Fields = new List<FieldObject>();
+                return;
+            }
+
+            for (int i = rowObject.Fields.Count - 1; i >= 0; i--)
+            {
+                var field = rowObject.Fields[i];
+                if (field == null)
+                {
+                    rowObject.Fields.RemoveAt(i);
+                    continue;
+                }
+
+                var key = CreateFieldKey(formId, rowObject.RowId, field.FieldNumber);
+                if (!baselineFieldMap.TryGetValue(key, out var baselineSnapshot))
+                {
+                    continue;
+                }
+
+                if (IsUnchanged(field, baselineSnapshot))
+                {
+                    rowObject.Fields.RemoveAt(i);
+                }
+            }
+        }
+
+        private static Dictionary<string, BaselineFieldSnapshot> BuildBaselineFieldMap(List<FormObject> baselineForms)
+        {
+            var map = new Dictionary<string, BaselineFieldSnapshot>();
+
+            foreach (var form in baselineForms.Where(f => f != null))
+            {
+                if (form.CurrentRow != null)
+                {
+                    AddRowToBaselineMap(map, form.FormId, form.CurrentRow);
+                }
+
+                if (form.OtherRows != null)
+                {
+                    foreach (var row in form.OtherRows.Where(r => r != null))
+                    {
+                        AddRowToBaselineMap(map, form.FormId, row);
+                    }
+                }
+            }
+
+            return map;
+        }
+
+        private static void AddRowToBaselineMap(Dictionary<string, BaselineFieldSnapshot> map, string formId, RowObject row)
+        {
+            if (row.Fields == null)
+            {
+                return;
+            }
+
+            foreach (var field in row.Fields.Where(f => f != null))
+            {
+                var key = CreateFieldKey(formId, row.RowId, field.FieldNumber);
+                map[key] = new BaselineFieldSnapshot(field.FieldValue, field.Enabled, field.Lock, field.Required);
+            }
+        }
+
+        private static string CreateFieldKey(string formId, string rowId, string fieldNumber)
+        {
+            return string.Concat(formId ?? string.Empty, "|", rowId ?? string.Empty, "|", fieldNumber ?? string.Empty);
+        }
+
+        private static bool IsUnchanged(FieldObject field, BaselineFieldSnapshot baselineSnapshot)
+        {
+            return string.Equals(field.FieldValue ?? string.Empty, baselineSnapshot.FieldValue, System.StringComparison.Ordinal)
+                && string.Equals(field.Enabled ?? string.Empty, baselineSnapshot.Enabled, System.StringComparison.Ordinal)
+                && string.Equals(field.Lock ?? string.Empty, baselineSnapshot.Lock, System.StringComparison.Ordinal)
+                && string.Equals(field.Required ?? string.Empty, baselineSnapshot.Required, System.StringComparison.Ordinal);
+        }
+
+        private static bool IsValidRowAction(string rowAction)
+        {
+            return rowAction == RowObject.RowActions.Add
+                || rowAction == RowObject.RowActions.Edit
+                || rowAction == RowObject.RowActions.Delete;
+        }
+
+        private sealed class BaselineFieldSnapshot
+        {
+            internal BaselineFieldSnapshot(string fieldValue, string enabled, string locked, string required)
+            {
+                FieldValue = fieldValue ?? string.Empty;
+                Enabled = enabled ?? string.Empty;
+                Lock = locked ?? string.Empty;
+                Required = required ?? string.Empty;
+            }
+
+            internal string FieldValue { get; }
+            internal string Enabled { get; }
+            internal string Lock { get; }
+            internal string Required { get; }
+        }
+    }
+}

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/ResponseFinalizationHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Builders/ResponseBuilders/ResponseFinalizationHelpers.cs
@@ -142,7 +142,11 @@ namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
                     continue;
                 }
 
-                var key = CreateFieldKey(formId, rowObject.RowId, field.FieldNumber);
+                if (!TryCreateFieldKey(formId, rowObject.RowId, field.FieldNumber, out var key))
+                {
+                    continue;
+                }
+
                 if (!baselineFieldMap.TryGetValue(key, out var baselineSnapshot))
                 {
                     continue;
@@ -187,14 +191,25 @@ namespace RarelySimple.AvatarScriptLink.Objects.Builders.ResponseBuilders
 
             foreach (var field in row.Fields.Where(f => f != null))
             {
-                var key = CreateFieldKey(formId, row.RowId, field.FieldNumber);
+                if (!TryCreateFieldKey(formId, row.RowId, field.FieldNumber, out var key))
+                {
+                    continue;
+                }
+
                 map[key] = new BaselineFieldSnapshot(field.FieldValue, field.Enabled, field.Lock, field.Required);
             }
         }
 
-        private static string CreateFieldKey(string formId, string rowId, string fieldNumber)
+        private static bool TryCreateFieldKey(string formId, string rowId, string fieldNumber, out string key)
         {
-            return string.Concat(formId ?? string.Empty, "|", rowId ?? string.Empty, "|", fieldNumber ?? string.Empty);
+            if (string.IsNullOrEmpty(formId) || string.IsNullOrEmpty(rowId) || string.IsNullOrEmpty(fieldNumber))
+            {
+                key = string.Empty;
+                return false;
+            }
+
+            key = string.Concat(formId, "|", rowId, "|", fieldNumber);
+            return true;
         }
 
         private static bool IsUnchanged(FieldObject field, BaselineFieldSnapshot baselineSnapshot)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/FormObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/FormObjectTests.cs
@@ -32,6 +32,25 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void FormObjectEquals_WhenOtherRowsNullAndEmpty_AreEqual()
+        {
+            FormObject formObject1 = new()
+            {
+                FormId = "1",
+                MultipleIteration = false,
+                OtherRows = null
+            };
+            FormObject formObject2 = new()
+            {
+                FormId = "1",
+                MultipleIteration = false,
+                OtherRows = []
+            };
+
+            Assert.IsTrue(formObject1.Equals(formObject2));
+        }
+
+        [TestMethod]
         public void FormObjectEqualsMethodIsTrue()
         {
             FormObject formObject1 = new()
@@ -228,6 +247,27 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
                 OtherRows = []
             };
             FormObject formObject2 = formObject1.Clone();
+            Assert.AreEqual(formObject1.GetHashCode(), formObject2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void FormObjectGetHashCode_WhenOtherRowsNullAndEmpty_AreEqual()
+        {
+            FormObject formObject1 = new()
+            {
+                FormId = "1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject(),
+                OtherRows = null
+            };
+            FormObject formObject2 = new()
+            {
+                FormId = "1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject(),
+                OtherRows = []
+            };
+
             Assert.AreEqual(formObject1.GetHashCode(), formObject2.GetHashCode());
         }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/FormObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/FormObjectTests.cs
@@ -17,6 +17,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void FormObjectClone_WhenOtherRowsAreNull_TreatsOtherRowsAsEmptyCollection()
+        {
+            FormObject formObject1 = new()
+            {
+                FormId = "1",
+                OtherRows = null
+            };
+
+            FormObject formObject2 = formObject1.Clone();
+
+            Assert.IsNotNull(formObject2.OtherRows);
+            Assert.AreEqual(0, formObject2.OtherRows.Count);
+        }
+
+        [TestMethod]
         public void FormObjectEqualsMethodIsTrue()
         {
             FormObject formObject1 = new()

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2015Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2015Tests.cs
@@ -17,6 +17,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void OptionObject2015Clone_WhenFormsAreNull_TreatsFormsAsEmptyCollection()
+        {
+            OptionObject2015 optionObject1 = new()
+            {
+                EntityID = "1",
+                Forms = null
+            };
+
+            OptionObject2015 optionObject2 = optionObject1.Clone();
+
+            Assert.IsNotNull(optionObject2.Forms);
+            Assert.AreEqual(0, optionObject2.Forms.Count);
+        }
+
+        [TestMethod]
         public void OptionObject2015EqualsMethodIsTrue()
         {
             OptionObject2015 optionObject1 = new()

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2015Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2015Tests.cs
@@ -32,6 +32,47 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void OptionObject2015Equals_WhenFormsNullAndEmpty_AreEqual()
+        {
+            OptionObject2015 optionObject1 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = null,
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SessionToken = "6",
+                SystemCode = "TEST"
+            };
+            OptionObject2015 optionObject2 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = [],
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SessionToken = "6",
+                SystemCode = "TEST"
+            };
+
+            Assert.IsTrue(optionObject1.Equals(optionObject2));
+        }
+
+        [TestMethod]
         public void OptionObject2015EqualsMethodIsTrue()
         {
             OptionObject2015 optionObject1 = new()
@@ -360,6 +401,47 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
                 SystemCode = "TEST"
             };
             OptionObject2015 optionObject2 = optionObject1.Clone();
+            Assert.AreEqual(optionObject1.GetHashCode(), optionObject2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void OptionObject2015GetHashCode_WhenFormsNullAndEmpty_AreEqual()
+        {
+            OptionObject2015 optionObject1 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = null,
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SessionToken = "6",
+                SystemCode = "TEST"
+            };
+            OptionObject2015 optionObject2 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = [],
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SessionToken = "6",
+                SystemCode = "TEST"
+            };
+
             Assert.AreEqual(optionObject1.GetHashCode(), optionObject2.GetHashCode());
         }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2Tests.cs
@@ -32,6 +32,45 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void OptionObject2Equals_WhenFormsNullAndEmpty_AreEqual()
+        {
+            OptionObject2 optionObject1 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = null,
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SystemCode = "TEST"
+            };
+            OptionObject2 optionObject2 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = [],
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SystemCode = "TEST"
+            };
+
+            Assert.IsTrue(optionObject1.Equals(optionObject2));
+        }
+
+        [TestMethod]
         public void OptionObject2EqualsMethodIsTrue()
         {
             OptionObject2 optionObject1 = new()
@@ -347,6 +386,45 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
                 SystemCode = "TEST"
             };
             OptionObject2 optionObject2 = optionObject1.Clone();
+            Assert.AreEqual(optionObject1.GetHashCode(), optionObject2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void OptionObject2GetHashCode_WhenFormsNullAndEmpty_AreEqual()
+        {
+            OptionObject2 optionObject1 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = null,
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SystemCode = "TEST"
+            };
+            OptionObject2 optionObject2 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = [],
+                NamespaceName = "Namespace",
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                ParentNamespace = "Parent",
+                ServerName = "Server",
+                SystemCode = "TEST"
+            };
+
             Assert.AreEqual(optionObject1.GetHashCode(), optionObject2.GetHashCode());
         }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObject2Tests.cs
@@ -17,6 +17,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void OptionObject2Clone_WhenFormsAreNull_TreatsFormsAsEmptyCollection()
+        {
+            OptionObject2 optionObject1 = new()
+            {
+                EntityID = "1",
+                Forms = null
+            };
+
+            OptionObject2 optionObject2 = optionObject1.Clone();
+
+            Assert.IsNotNull(optionObject2.Forms);
+            Assert.AreEqual(0, optionObject2.Forms.Count);
+        }
+
+        [TestMethod]
         public void OptionObject2EqualsMethodIsTrue()
         {
             OptionObject2 optionObject1 = new()

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObjectTests.cs
@@ -32,6 +32,39 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void OptionObjectEquals_WhenFormsNullAndEmpty_AreEqual()
+        {
+            OptionObject optionObject1 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = null,
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                SystemCode = "TEST"
+            };
+            OptionObject optionObject2 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = [],
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                SystemCode = "TEST"
+            };
+
+            Assert.IsTrue(optionObject1.Equals(optionObject2));
+        }
+
+        [TestMethod]
         public void OptionObjectEqualsMethodIsTrue()
         {
             OptionObject optionObject1 = new()
@@ -304,6 +337,39 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
                 SystemCode = "TEST"
             };
             OptionObject optionObject2 = optionObject1.Clone();
+            Assert.AreEqual(optionObject1.GetHashCode(), optionObject2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void OptionObjectGetHashCode_WhenFormsNullAndEmpty_AreEqual()
+        {
+            OptionObject optionObject1 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = null,
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                SystemCode = "TEST"
+            };
+            OptionObject optionObject2 = new()
+            {
+                EntityID = "1",
+                EpisodeNumber = 2,
+                ErrorCode = 3,
+                ErrorMesg = "Test response",
+                Facility = "4",
+                Forms = [],
+                OptionId = "OPTION001",
+                OptionStaffId = "5",
+                OptionUserId = "USER",
+                SystemCode = "TEST"
+            };
+
             Assert.AreEqual(optionObject1.GetHashCode(), optionObject2.GetHashCode());
         }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/OptionObjectTests.cs
@@ -17,6 +17,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void OptionObjectClone_WhenFormsAreNull_TreatsFormsAsEmptyCollection()
+        {
+            OptionObject optionObject1 = new()
+            {
+                EntityID = "1",
+                Forms = null
+            };
+
+            OptionObject optionObject2 = optionObject1.Clone();
+
+            Assert.IsNotNull(optionObject2.Forms);
+            Assert.AreEqual(0, optionObject2.Forms.Count);
+        }
+
+        [TestMethod]
         public void OptionObjectEqualsMethodIsTrue()
         {
             OptionObject optionObject1 = new()

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/RowObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/RowObjectTests.cs
@@ -17,6 +17,21 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void RowObjectClone_WhenFieldsAreNull_TreatsFieldsAsEmptyCollection()
+        {
+            RowObject rowObject1 = new()
+            {
+                RowId = "1",
+                Fields = null
+            };
+
+            RowObject rowObject2 = rowObject1.Clone();
+
+            Assert.IsNotNull(rowObject2.Fields);
+            Assert.AreEqual(0, rowObject2.Fields.Count);
+        }
+
+        [TestMethod]
         public void RowObjectEqualsMethodIsTrue()
         {
             RowObject rowObject1 = new()

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/RowObjectTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Tests/RowObjectTests.cs
@@ -32,6 +32,27 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
         }
 
         [TestMethod]
+        public void RowObjectEquals_WhenFieldsNullAndEmpty_AreEqual()
+        {
+            RowObject rowObject1 = new()
+            {
+                RowId = "2",
+                RowAction = string.Empty,
+                ParentRowId = "1",
+                Fields = null
+            };
+            RowObject rowObject2 = new()
+            {
+                RowId = "2",
+                RowAction = string.Empty,
+                ParentRowId = "1",
+                Fields = []
+            };
+
+            Assert.IsTrue(rowObject1.Equals(rowObject2));
+        }
+
+        [TestMethod]
         public void RowObjectEqualsMethodIsTrue()
         {
             RowObject rowObject1 = new()
@@ -230,6 +251,27 @@ namespace RarelySimple.AvatarScriptLink.Objects.Tests
                 Fields = []
             };
             RowObject rowObject2 = rowObject1.Clone();
+            Assert.AreEqual(rowObject1.GetHashCode(), rowObject2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void RowObjectGetHashCode_WhenFieldsNullAndEmpty_AreEqual()
+        {
+            RowObject rowObject1 = new()
+            {
+                RowId = "2",
+                RowAction = string.Empty,
+                ParentRowId = "1",
+                Fields = null
+            };
+            RowObject rowObject2 = new()
+            {
+                RowId = "2",
+                RowAction = string.Empty,
+                ParentRowId = "1",
+                Fields = []
+            };
+
             Assert.AreEqual(rowObject1.GetHashCode(), rowObject2.GetHashCode());
         }
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/FieldObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/FieldObject.cs
@@ -89,21 +89,24 @@ namespace RarelySimple.AvatarScriptLink.Objects
 
         public static bool AreFieldsEqual(List<FieldObject> list1, List<FieldObject> list2)
         {
-            if (!AreBothNull(list1, list2) && AreBothEmpty(list1, list2))
-                return true;
-            if (list1.Count != list2.Count)
+            var count1 = list1?.Count ?? 0;
+            var count2 = list2?.Count ?? 0;
+
+            if (count1 != count2)
                 return false;
-            for (int i = 0; i < list1.Count; i++)
+
+            for (int i = 0; i < count1; i++)
             {
-                if (!list1[i].Equals(list2[i]))
+                if (!Equals(list1[i], list2[i]))
                 {
                     return false;
                 }
             }
+
             return true;
         }
 
-        public static bool AreBothEmpty(List<FieldObject> list1, List<FieldObject> list2) => !list1.Any() && !list2.Any();
+        public static bool AreBothEmpty(List<FieldObject> list1, List<FieldObject> list2) => (list1?.Count ?? 0) == 0 && (list2?.Count ?? 0) == 0;
 
         public static bool AreBothNull(List<FieldObject> list1, List<FieldObject> list2) => list1 == null && list2 == null;
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/FormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/FormObject.cs
@@ -72,35 +72,33 @@ namespace RarelySimple.AvatarScriptLink.Objects
             hash = hash * 23 + (FormId != null ? FormId.GetHashCode() : 0);
             hash = hash * 23 + MultipleIteration.GetHashCode();
             hash = hash * 23 + (CurrentRow != null ? CurrentRow.GetHashCode() : 0);
-            if (OtherRows != null)
+            foreach (RowObject rowObject in OtherRows ?? Enumerable.Empty<RowObject>())
             {
-                foreach (RowObject rowObject in OtherRows)
-                {
-                    hash = hash * 23 + (rowObject != null ? rowObject.GetHashCode() : 0);
-                }
+                hash = hash * 23 + (rowObject != null ? rowObject.GetHashCode() : 0);
             }
             return hash;
         }
 
         public static bool AreFormsEqual(List<FormObject> list1, List<FormObject> list2)
         {
-            if (!AreBothNull(list1, list2) && AreBothEmpty(list1, list2))
-                return true;
+            var count1 = list1?.Count ?? 0;
+            var count2 = list2?.Count ?? 0;
 
-            if (list1.Count != list2.Count)
+            if (count1 != count2)
                 return false;
 
-            for (int i = 0; i < list1.Count; i++)
+            for (int i = 0; i < count1; i++)
             {
-                if (!list1[i].Equals(list2[i]))
+                if (!Equals(list1[i], list2[i]))
                 {
                     return false;
                 }
             }
+
             return true;
         }
 
-        public static bool AreBothEmpty(List<FormObject> list1, List<FormObject> list2) => !list1.Any() && !list2.Any();
+        public static bool AreBothEmpty(List<FormObject> list1, List<FormObject> list2) => (list1?.Count ?? 0) == 0 && (list2?.Count ?? 0) == 0;
 
         public static bool AreBothNull(List<FormObject> list1, List<FormObject> list2) => list1 == null && list2 == null;
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/FormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/FormObject.cs
@@ -25,7 +25,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             var formObject = (FormObject) MemberwiseClone();
             formObject.CurrentRow = CurrentRow?.Clone();
             formObject.OtherRows = new List<RowObject>();
-            foreach (var row in OtherRows.Where(r => r != null))
+            foreach (var row in OtherRows?.Where(r => r != null) ?? Enumerable.Empty<RowObject>())
             {
                 formObject.OtherRows.Add(row.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/FormObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/FormObject.cs
@@ -25,7 +25,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             var formObject = (FormObject) MemberwiseClone();
             formObject.CurrentRow = CurrentRow?.Clone();
             formObject.OtherRows = new List<RowObject>();
-            foreach (var row in OtherRows)
+            foreach (var row in OtherRows.Where(r => r != null))
             {
                 formObject.OtherRows.Add(row.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject.cs
@@ -30,7 +30,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var optionObject = (OptionObject) MemberwiseClone();
             optionObject.Forms = new List<FormObject>();
-            foreach (var form in Forms.Where(f => f != null))
+            foreach (var form in Forms?.Where(f => f != null) ?? Enumerable.Empty<FormObject>())
             {
                 optionObject.Forms.Add(form.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject.cs
@@ -30,7 +30,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var optionObject = (OptionObject) MemberwiseClone();
             optionObject.Forms = new List<FormObject>();
-            foreach (var form in Forms)
+            foreach (var form in Forms.Where(f => f != null))
             {
                 optionObject.Forms.Add(form.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject.cs
@@ -91,7 +91,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             hash = hash * 23 + (OptionStaffId != null ? OptionStaffId.GetHashCode() : 0);
             hash = hash * 23 + (OptionUserId != null ? OptionUserId.GetHashCode() : 0);
             hash = hash * 23 + (SystemCode != null ? SystemCode.GetHashCode() : 0);
-            foreach (FormObject formObject in Forms)
+            foreach (FormObject formObject in Forms ?? Enumerable.Empty<FormObject>())
             {
                 hash = hash * 23 + (formObject != null ? formObject.GetHashCode() : 0);
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2.cs
@@ -96,7 +96,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             hash = hash * 23 + (ParentNamespace != null ? ParentNamespace.GetHashCode() : 0);
             hash = hash * 23 + (ServerName != null ? ServerName.GetHashCode() : 0);
             hash = hash * 23 + (SystemCode != null ? SystemCode.GetHashCode() : 0);
-            foreach (FormObject formObject in Forms)
+            foreach (FormObject formObject in Forms ?? Enumerable.Empty<FormObject>())
             {
                 hash = hash * 23 + (formObject != null ? formObject.GetHashCode() : 0);
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2.cs
@@ -30,7 +30,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var optionObject = (OptionObject2) MemberwiseClone();
             optionObject.Forms = new List<FormObject>();
-            foreach (var form in Forms.Where(f => f != null))
+            foreach (var form in Forms?.Where(f => f != null) ?? Enumerable.Empty<FormObject>())
             {
                 optionObject.Forms.Add(form.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2.cs
@@ -30,7 +30,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var optionObject = (OptionObject2) MemberwiseClone();
             optionObject.Forms = new List<FormObject>();
-            foreach (var form in Forms)
+            foreach (var form in Forms.Where(f => f != null))
             {
                 optionObject.Forms.Add(form.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2015.cs
@@ -94,7 +94,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             hash = hash * 23 + (ServerName != null ? ServerName.GetHashCode() : 0);
             hash = hash * 23 + (SessionToken != null ? SessionToken.GetHashCode() : 0);
             hash = hash * 23 + (SystemCode != null ? SystemCode.GetHashCode() : 0);
-            foreach (FormObject formObject in Forms)
+            foreach (FormObject formObject in Forms ?? Enumerable.Empty<FormObject>())
             {
                 hash = hash * 23 + (formObject != null ? formObject.GetHashCode() : 0);
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2015.cs
@@ -26,7 +26,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var optionObject = (OptionObject2015) MemberwiseClone();
             optionObject.Forms = new List<FormObject>();
-            foreach (var form in Forms)
+            foreach (var form in Forms.Where(f => f != null))
             {
                 optionObject.Forms.Add(form.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2015.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/OptionObject2015.cs
@@ -26,7 +26,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var optionObject = (OptionObject2015) MemberwiseClone();
             optionObject.Forms = new List<FormObject>();
-            foreach (var form in Forms.Where(f => f != null))
+            foreach (var form in Forms?.Where(f => f != null) ?? Enumerable.Empty<FormObject>())
             {
                 optionObject.Forms.Add(form.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/RowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/RowObject.cs
@@ -66,7 +66,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
             hash = hash * 23 + (ParentRowId != null ? ParentRowId.GetHashCode() : 0);
             hash = hash * 23 + (RowAction != null ? RowAction.GetHashCode() : 0);
             hash = hash * 23 + (RowId != null ? RowId.GetHashCode() : 0);
-            foreach (FieldObject fieldObject in Fields)
+            foreach (FieldObject fieldObject in Fields ?? Enumerable.Empty<FieldObject>())
             {
                 hash = hash * 23 + (fieldObject != null ? fieldObject.GetHashCode() : 0);
             }
@@ -75,21 +75,24 @@ namespace RarelySimple.AvatarScriptLink.Objects
 
         public static bool AreRowsEqual(List<RowObject> list1, List<RowObject> list2)
         {
-            if (!AreBothNull(list1, list2) && AreBothEmpty(list1, list2))
-                return true;
-            if (list1.Count != list2.Count)
+            var count1 = list1?.Count ?? 0;
+            var count2 = list2?.Count ?? 0;
+
+            if (count1 != count2)
                 return false;
-            for (int i = 0; i < list1.Count; i++)
+
+            for (int i = 0; i < count1; i++)
             {
-                if (!list1[i].Equals(list2[i]))
+                if (!Equals(list1[i], list2[i]))
                 {
                     return false;
                 }
             }
+
             return true;
         }
 
-        public static bool AreBothEmpty(List<RowObject> list1, List<RowObject> list2) => !list1.Any() && !list2.Any();
+        public static bool AreBothEmpty(List<RowObject> list1, List<RowObject> list2) => (list1?.Count ?? 0) == 0 && (list2?.Count ?? 0) == 0;
 
         public static bool AreBothNull(List<RowObject> list1, List<RowObject> list2) => list1 == null && list2 == null;
 

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/RowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/RowObject.cs
@@ -21,7 +21,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var rowObject = (RowObject) MemberwiseClone();
             rowObject.Fields = new List<FieldObject>();
-            foreach (var field in Fields)
+            foreach (var field in Fields.Where(f => f != null))
             {
                 rowObject.Fields.Add(field.Clone());
             }

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects/RowObject.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects/RowObject.cs
@@ -21,7 +21,7 @@ namespace RarelySimple.AvatarScriptLink.Objects
         {
             var rowObject = (RowObject) MemberwiseClone();
             rowObject.Fields = new List<FieldObject>();
-            foreach (var field in Fields.Where(f => f != null))
+            foreach (var field in Fields?.Where(f => f != null) ?? Enumerable.Empty<FieldObject>())
             {
                 rowObject.Fields.Add(field.Clone());
             }


### PR DESCRIPTION
- Introduced new extension methods in OptionObject, OptionObject2, and OptionObject2015 response builders to create return payloads with error handling and baseline comparison.
- Added ResponseFinalizationHelpers class to encapsulate logic for removing unedited rows from forms and rows based on baseline comparisons.
- Updated cloning logic in FormObject, OptionObject, OptionObject2, and OptionObject2015 to handle null checks for rows and forms.
- Enhanced RowObject cloning to ensure null checks for fields.

## Notable Changes for v2

### RemoveUneditedRows in v2 will be treated as internal functionality

`RemoveUneditedRows()` in v2 will be treated as internal functionality rather than exposed as a public method. This can be revisited during beta testing if developers find value in calling that directly.

### Response OptionObject Size Optimization Now Optional

When calling `ToReturnOptionObject()` in v2 unmodified FieldObjects will not be removed from edited RowObjects by default.

```
var oo = request.Clone();
oo.SetFieldValue("123.45", "Modified");
return oo.ToReturnOptionObject();
```

To further reduce the response size, include the original request for baseline comparison.

```
var oo = request.Clone();
oo.SetFieldValue("123.45", "Modified");
return oo.ToReturnOptionObject(request);
```

This is to reduce the complexity and impact to the base objects allowing for safer use of the Objects library without intrusion of functionality only leveraged by the helpers.