### PR TITLE
Add row management methods to FormObject and OptionObject helpers

### DIFF
--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
@@ -311,6 +311,144 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void GetNextAvailableRowId_FormObject_WithSparseIdsNearMaximum_ReturnsMissingInRangeId()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+
+            for (int i = 2; i <= 9999; i++)
+            {
+                if (i == 5000)
+                {
+                    continue;
+                }
+
+                form.OtherRows.Add(new RowObject { RowId = $"FORM1||{i}" });
+            }
+
+            // Keeps row count at previous guard threshold without occupying the missing in-range candidate.
+            form.OtherRows.Add(new RowObject { RowId = "FORM1||10000" });
+
+            // Act
+            var result = form.GetNextAvailableRowId();
+
+            // Assert
+            Assert.AreEqual("FORM1||5000", result);
+        }
+
+        [TestMethod]
+        public void GetNextAvailableRowId_FormObject_WithAllInRangeIdsUsed_ThrowsArgumentException()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+
+            for (int i = 2; i <= 9999; i++)
+            {
+                form.OtherRows.Add(new RowObject { RowId = $"FORM1||{i}" });
+            }
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => form.GetNextAvailableRowId());
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_DefaultOverload_SetsAddAction()
+        {
+            // Arrange
+            var form = new FormObject { FormId = "FORM2", MultipleIteration = true };
+
+            // Act
+            form.AddRowObject();
+
+            // Assert
+            Assert.IsNotNull(form.CurrentRow);
+            Assert.AreEqual("FORM2||1", form.CurrentRow.RowId);
+            Assert.AreEqual(RowObject.RowActions.Add, form.CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithRowIdParentRowIdOverload_AssignsProvidedValues()
+        {
+            // Arrange
+            var form = new FormObject { FormId = "FORM3", MultipleIteration = true };
+
+            // Act
+            form.AddRowObject("FORM3||10", "PARENT1");
+
+            // Assert
+            Assert.IsNotNull(form.CurrentRow);
+            Assert.AreEqual("FORM3||10", form.CurrentRow.RowId);
+            Assert.AreEqual("PARENT1", form.CurrentRow.ParentRowId);
+            Assert.AreEqual(RowObject.RowActions.Add, form.CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void AddRowObjectWithParentRowId_FormObject_AssignsParentAndAddAction()
+        {
+            // Arrange
+            var form = new FormObject { FormId = "FORM4", MultipleIteration = true };
+
+            // Act
+            form.AddRowObjectWithParentRowId("PARENT2");
+
+            // Assert
+            Assert.IsNotNull(form.CurrentRow);
+            Assert.AreEqual("PARENT2", form.CurrentRow.ParentRowId);
+            Assert.AreEqual(RowObject.RowActions.Add, form.CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithNullFormObject_ThrowsArgumentNullException()
+        {
+            // Arrange
+            FormObject form = null!;
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentNullException>(() => FormObjectHelpers.AddRowObject(form, new RowObject()));
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var form = new FormObject { FormId = "FORM5", MultipleIteration = true };
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentNullException>(() => form.AddRowObject((RowObject)null!));
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithNullOtherRows_InitializesAndAddsRow()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM6",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM6||1" },
+                OtherRows = null!
+            };
+
+            // Act
+            form.AddRowObject(new RowObject { RowAction = RowObject.RowActions.Add });
+
+            // Assert
+            Assert.IsNotNull(form.OtherRows);
+            Assert.AreEqual(1, form.OtherRows.Count);
+            Assert.AreEqual("FORM6||2", form.OtherRows[0].RowId);
+        }
+
+        [TestMethod]
         public void AddRowObject_FormObject_WithCurrentRow_AddsOtherRowWithGeneratedId()
         {
             // Arrange
@@ -418,6 +556,49 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
 
             // Act / Assert
             Assert.ThrowsException<ArgumentException>(() => form.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_FormObject_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "FORM1||1" } };
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentNullException>(() => form.DeleteRowObject((RowObject)null!));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_FormObject_WithEmptyRowId_ThrowsArgumentException()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "FORM1||1" } };
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => form.DeleteRowObject(string.Empty));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_FormObject_WithNullFormObject_ThrowsArgumentNullException()
+        {
+            // Arrange
+            FormObject form = null!;
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentNullException>(() => FormObjectHelpers.DeleteRowObject(form, "FORM1||1"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_FormObject_WithRowObject_DelegatesToRowIdDelete()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "FORM1||1", RowAction = RowObject.RowActions.None } };
+
+            // Act
+            form.DeleteRowObject(new RowObject { RowId = "FORM1||1" });
+
+            // Assert
+            Assert.AreEqual(RowObject.RowActions.Delete, form.CurrentRow.RowAction);
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
@@ -277,6 +277,150 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void GetNextAvailableRowId_FormObject_WithGaps_ReturnsFirstAvailableRowId()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM1||3" });
+
+            // Act
+            var result = form.GetNextAvailableRowId();
+
+            // Assert
+            Assert.AreEqual("FORM1||2", result);
+        }
+
+        [TestMethod]
+        public void GetNextAvailableRowId_FormObject_NonMultipleIterationWithCurrentRow_ThrowsArgumentOutOfRangeException()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = false,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => form.GetNextAvailableRowId());
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithCurrentRow_AddsOtherRowWithGeneratedId()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+
+            // Act
+            form.AddRowObject(new RowObject { RowAction = RowObject.RowActions.Add });
+
+            // Assert
+            Assert.AreEqual(1, form.OtherRows.Count);
+            Assert.AreEqual("FORM1||2", form.OtherRows[0].RowId);
+            Assert.AreEqual(RowObject.RowActions.Add, form.OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithNoCurrentRow_SetsCurrentRowAndGeneratedId()
+        {
+            // Arrange
+            var form = new FormObject { FormId = "FORM2", MultipleIteration = true };
+
+            // Act
+            form.AddRowObject(new RowObject { RowAction = RowObject.RowActions.Add });
+
+            // Assert
+            Assert.IsNotNull(form.CurrentRow);
+            Assert.AreEqual("FORM2||1", form.CurrentRow.RowId);
+            Assert.AreEqual(RowObject.RowActions.Add, form.CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithDuplicateRowId_ThrowsArgumentException()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => form.AddRowObject(new RowObject { RowId = "FORM1||1" }));
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_NonMultipleIterationWithCurrentRow_ThrowsArgumentException()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = false,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => form.AddRowObject());
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_FormObject_WithCurrentRow_MarksDelete()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = new RowObject { RowId = "FORM1||1", RowAction = RowObject.RowActions.None } };
+
+            // Act
+            form.DeleteRowObject("FORM1||1");
+
+            // Assert
+            Assert.AreEqual(RowObject.RowActions.Delete, form.CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_FormObject_WithOtherRow_MarksDelete()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM1||2", RowAction = RowObject.RowActions.None });
+
+            // Act
+            form.DeleteRowObject("FORM1||2");
+
+            // Assert
+            Assert.AreEqual(RowObject.RowActions.Delete, form.OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_FormObject_WithMissingRow_ThrowsArgumentException()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => form.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
         public void IsRowPresent_FormObject_WithCurrentRow_ReturnsTrue()
         {
             // Arrange

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
@@ -342,7 +342,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
-        public void GetNextAvailableRowId_FormObject_WithAllInRangeIdsUsed_ThrowsArgumentException()
+        public void GetNextAvailableRowId_FormObject_WithAllInRangeIdsUsed_ThrowsArgumentOutOfRangeException()
         {
             // Arrange
             var form = new FormObject
@@ -358,7 +358,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             }
 
             // Act / Assert
-            Assert.ThrowsException<ArgumentException>(() => form.GetNextAvailableRowId());
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => form.GetNextAvailableRowId());
         }
 
         [TestMethod]
@@ -481,6 +481,22 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             Assert.IsNotNull(form.CurrentRow);
             Assert.AreEqual("FORM2||1", form.CurrentRow.RowId);
             Assert.AreEqual(RowObject.RowActions.Add, form.CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void AddRowObject_FormObject_WithNoCurrentRowAndDuplicateOtherRowId_ThrowsArgumentException()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                FormId = "FORM2",
+                MultipleIteration = true,
+                CurrentRow = null!
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM2||5" });
+
+            // Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => form.AddRowObject(new RowObject { RowId = "FORM2||5", RowAction = RowObject.RowActions.Add }));
         }
 
         [TestMethod]
@@ -619,6 +635,20 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         {
             // Arrange
             var form = new FormObject { CurrentRow = new RowObject { RowId = "1" }, MultipleIteration = true };
+            form.OtherRows.Add(new RowObject { RowId = "2" });
+
+            // Act
+            var result = form.IsRowPresent("2");
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public void IsRowPresent_FormObject_WithOtherRowAndNoCurrentRow_ReturnsTrue()
+        {
+            // Arrange
+            var form = new FormObject { CurrentRow = null!, MultipleIteration = true };
             form.OtherRows.Add(new RowObject { RowId = "2" });
 
             // Act

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/FormObjectHelpersTests.cs
@@ -561,6 +561,24 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void DeleteRowObject_FormObject_WithOtherRowAndNonMultipleIteration_MarksDelete()
+        {
+            // Arrange
+            var form = new FormObject
+            {
+                MultipleIteration = false,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM1||2", RowAction = RowObject.RowActions.None });
+
+            // Act
+            form.DeleteRowObject("FORM1||2");
+
+            // Assert
+            Assert.AreEqual(RowObject.RowActions.Delete, form.OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
         public void DeleteRowObject_FormObject_WithMissingRow_ThrowsArgumentException()
         {
             // Arrange

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
@@ -287,13 +287,11 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
-        public void AddRowObject_OptionObject_WithNullForms_ReturnsUnchangedOptionObject()
+        public void AddRowObject_OptionObject_WithNullForms_ThrowsArgumentException()
         {
             var optionObject = new OptionObject { Forms = null! };
 
-            var result = optionObject.AddRowObject("FORM1", new RowObject { RowAction = RowObject.RowActions.Add });
-
-            Assert.AreSame(optionObject, result);
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject("FORM1", new RowObject { RowAction = RowObject.RowActions.Add }));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
@@ -210,6 +210,85 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void GetNextAvailableRowId_OptionObject_ReturnsNextRowIdFromMatchingForm()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM1||2" });
+            optionObject.Forms.Add(form);
+
+            var result = optionObject.GetNextAvailableRowId("FORM1");
+
+            Assert.AreEqual("FORM1||3", result);
+        }
+
+        [TestMethod]
+        public void GetNextAvailableRowId_OptionObject_WithNonExistentForm_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.GetNextAvailableRowId("MISSING"));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject_WithMatchingForm_AddsRowToForm()
+        {
+            var optionObject = new OptionObject();
+            optionObject.Forms.Add(new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            });
+
+            optionObject.AddRowObject("FORM1", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreEqual(1, optionObject.Forms[0].OtherRows.Count);
+            Assert.AreEqual("FORM1||2", optionObject.Forms[0].OtherRows[0].RowId);
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject_WithMissingForm_DoesNotAddRow()
+        {
+            var optionObject = new OptionObject();
+            optionObject.Forms.Add(new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            });
+
+            optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreEqual(0, optionObject.Forms[0].OtherRows.Count);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject_WithRowObject_MarksDelete()
+        {
+            var optionObject = new OptionObject();
+            optionObject.Forms.Add(new FormObject { FormId = "FORM1", CurrentRow = new RowObject { RowId = "FORM1||1", RowAction = RowObject.RowActions.None } });
+
+            optionObject.DeleteRowObject(new RowObject { RowId = "FORM1||1" });
+
+            Assert.AreEqual(RowObject.RowActions.Delete, optionObject.Forms[0].CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject_WithMissingRow_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject();
+            optionObject.Forms.Add(new FormObject { FormId = "FORM1", CurrentRow = new RowObject { RowId = "FORM1||1" } });
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
         public void GetParentRowId_OptionObject_ReturnsParentRowId()
         {
             var optionObject = new OptionObject();

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
@@ -287,6 +287,24 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void DeleteRowObject_OptionObject_WithOtherRowAndNonMultipleIteration_MarksDelete()
+        {
+            var optionObject = new OptionObject();
+            var form = new FormObject
+            {
+                FormId = "FORM1",
+                MultipleIteration = false,
+                CurrentRow = new RowObject { RowId = "FORM1||1" }
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM1||2", RowAction = RowObject.RowActions.None });
+            optionObject.Forms.Add(form);
+
+            optionObject.DeleteRowObject("FORM1||2");
+
+            Assert.AreEqual(RowObject.RowActions.Delete, optionObject.Forms[0].OtherRows[0].RowAction);
+        }
+
+        [TestMethod]
         public void AddRowObject_OptionObject_WithNullForms_ThrowsArgumentException()
         {
             var optionObject = new OptionObject { Forms = null! };

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject.Tests.cs
@@ -253,7 +253,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
-        public void AddRowObject_OptionObject_WithMissingForm_DoesNotAddRow()
+        public void AddRowObject_OptionObject_WithMissingForm_ThrowsArgumentException()
         {
             var optionObject = new OptionObject();
             optionObject.Forms.Add(new FormObject
@@ -263,9 +263,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 CurrentRow = new RowObject { RowId = "FORM1||1" }
             });
 
-            optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add });
-
-            Assert.AreEqual(0, optionObject.Forms[0].OtherRows.Count);
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add }));
         }
 
         [TestMethod]
@@ -286,6 +284,72 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             optionObject.Forms.Add(new FormObject { FormId = "FORM1", CurrentRow = new RowObject { RowId = "FORM1||1" } });
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject_WithNullForms_ReturnsUnchangedOptionObject()
+        {
+            var optionObject = new OptionObject { Forms = null! };
+
+            var result = optionObject.AddRowObject("FORM1", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreSame(optionObject, result);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject_WithNullForms_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject { Forms = null! };
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("FORM1||1"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            var optionObject = new OptionObject();
+
+            Assert.ThrowsException<ArgumentNullException>(() => optionObject.DeleteRowObject((RowObject)null!));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject_WithNullOptionObject_ThrowsArgumentNullException()
+        {
+            OptionObject optionObject = null!;
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.AddRowObject(optionObject, "FORM1", new RowObject()));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject_WithEmptyFormId_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject(string.Empty, new RowObject()));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            var optionObject = new OptionObject();
+
+            Assert.ThrowsException<ArgumentNullException>(() => optionObject.AddRowObject("FORM1", null!));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject_WithNullOptionObject_ThrowsArgumentNullException()
+        {
+            OptionObject optionObject = null!;
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObjectHelpers.DeleteRowObject(optionObject, "FORM1||1"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject_WithEmptyRowId_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject(string.Empty));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
@@ -273,7 +273,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
-        public void AddRowObject_OptionObject2_WithMissingForm_DoesNotAddRow()
+        public void AddRowObject_OptionObject2_WithMissingForm_ThrowsArgumentException()
         {
             var optionObject = new OptionObject2();
             optionObject.Forms.Add(new FormObject
@@ -283,9 +283,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 CurrentRow = new RowObject { RowId = "FORM2||1" }
             });
 
-            optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add });
-
-            Assert.AreEqual(0, optionObject.Forms[0].OtherRows.Count);
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add }));
         }
 
         [TestMethod]
@@ -306,6 +304,72 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             optionObject.Forms.Add(new FormObject { FormId = "FORM2", CurrentRow = new RowObject { RowId = "FORM2||1" } });
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2_WithNullForms_ReturnsUnchangedOptionObject()
+        {
+            var optionObject = new OptionObject2 { Forms = null! };
+
+            var result = optionObject.AddRowObject("FORM2", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreSame(optionObject, result);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2_WithNullForms_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2 { Forms = null! };
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("FORM2||1"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            var optionObject = new OptionObject2();
+
+            Assert.ThrowsException<ArgumentNullException>(() => optionObject.DeleteRowObject((RowObject)null!));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2_WithNullOptionObject_ThrowsArgumentNullException()
+        {
+            OptionObject2 optionObject = null!;
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObject2Helpers.AddRowObject(optionObject, "FORM2", new RowObject()));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2_WithEmptyFormId_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject(string.Empty, new RowObject()));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            var optionObject = new OptionObject2();
+
+            Assert.ThrowsException<ArgumentNullException>(() => optionObject.AddRowObject("FORM2", null!));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2_WithNullOptionObject_ThrowsArgumentNullException()
+        {
+            OptionObject2 optionObject = null!;
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObject2Helpers.DeleteRowObject(optionObject, "FORM2||1"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2_WithEmptyRowId_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject(string.Empty));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
@@ -307,13 +307,11 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
-        public void AddRowObject_OptionObject2_WithNullForms_ReturnsUnchangedOptionObject()
+        public void AddRowObject_OptionObject2_WithNullForms_ThrowsArgumentException()
         {
             var optionObject = new OptionObject2 { Forms = null! };
 
-            var result = optionObject.AddRowObject("FORM2", new RowObject { RowAction = RowObject.RowActions.Add });
-
-            Assert.AreSame(optionObject, result);
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject("FORM2", new RowObject { RowAction = RowObject.RowActions.Add }));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2.Tests.cs
@@ -230,6 +230,85 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void GetNextAvailableRowId_OptionObject2_ReturnsNextRowIdFromMatchingForm()
+        {
+            var optionObject = new OptionObject2();
+            var form = new FormObject
+            {
+                FormId = "FORM2",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM2||1" }
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM2||3" });
+            optionObject.Forms.Add(form);
+
+            var result = optionObject.GetNextAvailableRowId("FORM2");
+
+            Assert.AreEqual("FORM2||2", result);
+        }
+
+        [TestMethod]
+        public void GetNextAvailableRowId_OptionObject2_WithNonExistentForm_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.GetNextAvailableRowId("MISSING"));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2_WithMatchingForm_AddsRowToForm()
+        {
+            var optionObject = new OptionObject2();
+            optionObject.Forms.Add(new FormObject
+            {
+                FormId = "FORM2",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM2||1" }
+            });
+
+            optionObject.AddRowObject("FORM2", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreEqual(1, optionObject.Forms[0].OtherRows.Count);
+            Assert.AreEqual("FORM2||2", optionObject.Forms[0].OtherRows[0].RowId);
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2_WithMissingForm_DoesNotAddRow()
+        {
+            var optionObject = new OptionObject2();
+            optionObject.Forms.Add(new FormObject
+            {
+                FormId = "FORM2",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM2||1" }
+            });
+
+            optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreEqual(0, optionObject.Forms[0].OtherRows.Count);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2_WithRowObject_MarksDelete()
+        {
+            var optionObject = new OptionObject2();
+            optionObject.Forms.Add(new FormObject { FormId = "FORM2", CurrentRow = new RowObject { RowId = "FORM2||1", RowAction = RowObject.RowActions.None } });
+
+            optionObject.DeleteRowObject(new RowObject { RowId = "FORM2||1" });
+
+            Assert.AreEqual(RowObject.RowActions.Delete, optionObject.Forms[0].CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2_WithMissingRow_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2();
+            optionObject.Forms.Add(new FormObject { FormId = "FORM2", CurrentRow = new RowObject { RowId = "FORM2||1" } });
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
         public void HasError_OptionObject2_WithZeroErrorCode_ReturnsFalse()
         {
             var optionObject = new OptionObject2 { ErrorCode = 0 };

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
@@ -230,6 +230,85 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
+        public void GetNextAvailableRowId_OptionObject2015_ReturnsNextRowIdFromMatchingForm()
+        {
+            var optionObject = new OptionObject2015();
+            var form = new FormObject
+            {
+                FormId = "FORM2015",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM2015||1" }
+            };
+            form.OtherRows.Add(new RowObject { RowId = "FORM2015||2" });
+            optionObject.Forms.Add(form);
+
+            var result = optionObject.GetNextAvailableRowId("FORM2015");
+
+            Assert.AreEqual("FORM2015||3", result);
+        }
+
+        [TestMethod]
+        public void GetNextAvailableRowId_OptionObject2015_WithNonExistentForm_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2015();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.GetNextAvailableRowId("MISSING"));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2015_WithMatchingForm_AddsRowToForm()
+        {
+            var optionObject = new OptionObject2015();
+            optionObject.Forms.Add(new FormObject
+            {
+                FormId = "FORM2015",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM2015||1" }
+            });
+
+            optionObject.AddRowObject("FORM2015", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreEqual(1, optionObject.Forms[0].OtherRows.Count);
+            Assert.AreEqual("FORM2015||2", optionObject.Forms[0].OtherRows[0].RowId);
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2015_WithMissingForm_DoesNotAddRow()
+        {
+            var optionObject = new OptionObject2015();
+            optionObject.Forms.Add(new FormObject
+            {
+                FormId = "FORM2015",
+                MultipleIteration = true,
+                CurrentRow = new RowObject { RowId = "FORM2015||1" }
+            });
+
+            optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreEqual(0, optionObject.Forms[0].OtherRows.Count);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2015_WithRowObject_MarksDelete()
+        {
+            var optionObject = new OptionObject2015();
+            optionObject.Forms.Add(new FormObject { FormId = "FORM2015", CurrentRow = new RowObject { RowId = "FORM2015||1", RowAction = RowObject.RowActions.None } });
+
+            optionObject.DeleteRowObject(new RowObject { RowId = "FORM2015||1" });
+
+            Assert.AreEqual(RowObject.RowActions.Delete, optionObject.Forms[0].CurrentRow.RowAction);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2015_WithMissingRow_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2015();
+            optionObject.Forms.Add(new FormObject { FormId = "FORM2015", CurrentRow = new RowObject { RowId = "FORM2015||1" } });
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
         public void GetSessionToken_OptionObject2015_ReturnsSessionToken()
         {
             var optionObject = new OptionObject2015 { SessionToken = "token-123" };

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
@@ -273,7 +273,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
-        public void AddRowObject_OptionObject2015_WithMissingForm_DoesNotAddRow()
+        public void AddRowObject_OptionObject2015_WithMissingForm_ThrowsArgumentException()
         {
             var optionObject = new OptionObject2015();
             optionObject.Forms.Add(new FormObject
@@ -283,9 +283,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
                 CurrentRow = new RowObject { RowId = "FORM2015||1" }
             });
 
-            optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add });
-
-            Assert.AreEqual(0, optionObject.Forms[0].OtherRows.Count);
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject("MISSING", new RowObject { RowAction = RowObject.RowActions.Add }));
         }
 
         [TestMethod]
@@ -306,6 +304,72 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
             optionObject.Forms.Add(new FormObject { FormId = "FORM2015", CurrentRow = new RowObject { RowId = "FORM2015||1" } });
 
             Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("MISSING"));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2015_WithNullForms_ReturnsUnchangedOptionObject()
+        {
+            var optionObject = new OptionObject2015 { Forms = null! };
+
+            var result = optionObject.AddRowObject("FORM2015", new RowObject { RowAction = RowObject.RowActions.Add });
+
+            Assert.AreSame(optionObject, result);
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2015_WithNullForms_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2015 { Forms = null! };
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject("FORM2015||1"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2015_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            var optionObject = new OptionObject2015();
+
+            Assert.ThrowsException<ArgumentNullException>(() => optionObject.DeleteRowObject((RowObject)null!));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2015_WithNullOptionObject_ThrowsArgumentNullException()
+        {
+            OptionObject2015 optionObject = null!;
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObject2015Helpers.AddRowObject(optionObject, "FORM2015", new RowObject()));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2015_WithEmptyFormId_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2015();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject(string.Empty, new RowObject()));
+        }
+
+        [TestMethod]
+        public void AddRowObject_OptionObject2015_WithNullRowObject_ThrowsArgumentNullException()
+        {
+            var optionObject = new OptionObject2015();
+
+            Assert.ThrowsException<ArgumentNullException>(() => optionObject.AddRowObject("FORM2015", null!));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2015_WithNullOptionObject_ThrowsArgumentNullException()
+        {
+            OptionObject2015 optionObject = null!;
+
+            Assert.ThrowsException<ArgumentNullException>(() => OptionObject2015Helpers.DeleteRowObject(optionObject, "FORM2015||1"));
+        }
+
+        [TestMethod]
+        public void DeleteRowObject_OptionObject2015_WithEmptyRowId_ThrowsArgumentException()
+        {
+            var optionObject = new OptionObject2015();
+
+            Assert.ThrowsException<ArgumentException>(() => optionObject.DeleteRowObject(string.Empty));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers.Tests/OptionObjectHelpers.OptionObject2015.Tests.cs
@@ -307,13 +307,11 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers.Tests
         }
 
         [TestMethod]
-        public void AddRowObject_OptionObject2015_WithNullForms_ReturnsUnchangedOptionObject()
+        public void AddRowObject_OptionObject2015_WithNullForms_ThrowsArgumentException()
         {
             var optionObject = new OptionObject2015 { Forms = null! };
 
-            var result = optionObject.AddRowObject("FORM2015", new RowObject { RowAction = RowObject.RowActions.Add });
-
-            Assert.AreSame(optionObject, result);
+            Assert.ThrowsException<ArgumentException>(() => optionObject.AddRowObject("FORM2015", new RowObject { RowAction = RowObject.RowActions.Add }));
         }
 
         [TestMethod]

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -115,7 +115,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
                 }
             }
 
-            throw new ArgumentException("Could not determine next available row ID.", nameof(formObject));
+            throw new ArgumentOutOfRangeException(nameof(formObject), "Could not determine next available row ID because no allocatable row IDs remain.");
         }
 
         /// <summary>
@@ -177,6 +177,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// Adds a new row to a <see cref="FormObject"/> with row action set to <see cref="RowObject.RowActions.Add"/>.
         /// </summary>
         /// <param name="formObject">The form to modify.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when constraints prevent adding the row, such as non-multiple-iteration forms with an existing current row or duplicate row IDs.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when another row cannot be added due to form constraints.</exception>
         /// <returns>The modified form.</returns>
         public static FormObject AddRowObject(this FormObject formObject)
         {
@@ -192,6 +195,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// <param name="formObject">The form to modify.</param>
         /// <param name="rowId">The row ID to assign.</param>
         /// <param name="parentRowId">The parent row ID to assign.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when constraints prevent adding the row, such as non-multiple-iteration forms with an existing current row or duplicate row IDs.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when another row cannot be added due to form constraints.</exception>
         /// <returns>The modified form.</returns>
         public static FormObject AddRowObject(this FormObject formObject, string rowId, string parentRowId)
         {
@@ -205,6 +211,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// <param name="rowId">The row ID to assign.</param>
         /// <param name="parentRowId">The parent row ID to assign.</param>
         /// <param name="rowAction">The row action to assign.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when constraints prevent adding the row, such as non-multiple-iteration forms with an existing current row or duplicate row IDs.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when another row cannot be added due to form constraints.</exception>
         /// <returns>The modified form.</returns>
         public static FormObject AddRowObject(this FormObject formObject, string rowId, string parentRowId, string rowAction)
         {
@@ -221,6 +230,9 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// </summary>
         /// <param name="formObject">The form to modify.</param>
         /// <param name="parentRowId">The parent row ID to assign.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when constraints prevent adding the row, such as non-multiple-iteration forms with an existing current row or duplicate row IDs.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when another row cannot be added due to form constraints.</exception>
         /// <returns>The modified form.</returns>
         public static FormObject AddRowObjectWithParentRowId(this FormObject formObject, string parentRowId)
         {
@@ -458,18 +470,13 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// <returns>True if the row is present, false otherwise.</returns>
         public static bool IsRowPresent(this FormObject formObject, string rowId)
         {
-            if (formObject == null || formObject.CurrentRow == null || string.IsNullOrEmpty(rowId))
+            if (formObject == null || string.IsNullOrEmpty(rowId))
                 return false;
 
-            if (formObject.CurrentRow.RowId == rowId)
+            if (formObject.CurrentRow?.RowId == rowId)
                 return true;
 
-            if (formObject.MultipleIteration && formObject.HasOtherRows())
-            {
-                return formObject.OtherRows.Any(r => r.RowId == rowId);
-            }
-
-            return false;
+            return formObject.OtherRows?.Any(r => r != null && r.RowId == rowId) ?? false;
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -10,6 +10,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
     /// </summary>
     public static class FormObjectHelpers
     {
+        private const int MaximumNumberOfMultipleIterationRows = 9999;
+
         /// <summary>
         /// Gets the form ID of a <see cref="FormObject"/>.
         /// </summary>
@@ -72,6 +74,223 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         public static string? GetParentRowId(this FormObject formObject)
         {
             return formObject?.CurrentRow?.ParentRowId;
+        }
+
+        /// <summary>
+        /// Gets the next available row ID for a <see cref="FormObject"/> using the pattern <c>formId||n</c>.
+        /// </summary>
+        /// <param name="formObject">The form object to evaluate.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the form ID is missing or a row ID cannot be determined.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when another row cannot be added due to form constraints.</exception>
+        /// <returns>The next available row ID.</returns>
+        public static string GetNextAvailableRowId(this FormObject formObject)
+        {
+            if (formObject == null)
+            {
+                throw new ArgumentNullException(nameof(formObject));
+            }
+
+            if (string.IsNullOrEmpty(formObject.FormId))
+            {
+                throw new ArgumentException("FormId cannot be null or empty.", nameof(formObject));
+            }
+
+            var currentRow = formObject.CurrentRow;
+            var otherRows = formObject.OtherRows ?? new List<RowObject>();
+
+            if (currentRow != null && !formObject.MultipleIteration)
+            {
+                throw new ArgumentOutOfRangeException(nameof(formObject), "Cannot add another row to a non-multiple-iteration form.");
+            }
+
+            if (currentRow != null && otherRows.Count + 1 >= MaximumNumberOfMultipleIterationRows)
+            {
+                throw new ArgumentOutOfRangeException(nameof(formObject), "Cannot add another row because the maximum row count was reached.");
+            }
+
+            for (int i = 1; i <= MaximumNumberOfMultipleIterationRows; i++)
+            {
+                var candidateRowId = string.Concat(formObject.FormId, "||", i.ToString());
+                var isCurrentMatch = currentRow != null && currentRow.RowId == candidateRowId;
+                var isOtherMatch = otherRows.Any(r => r != null && r.RowId == candidateRowId);
+                if (!isCurrentMatch && !isOtherMatch)
+                {
+                    return candidateRowId;
+                }
+            }
+
+            throw new ArgumentException("Could not determine next available row ID.", nameof(formObject));
+        }
+
+        /// <summary>
+        /// Adds a row to a <see cref="FormObject"/>.
+        /// </summary>
+        /// <param name="formObject">The form to modify.</param>
+        /// <param name="rowObject">The row to add.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> or <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when constraints prevent adding the row.</exception>
+        /// <returns>The modified form.</returns>
+        public static FormObject AddRowObject(this FormObject formObject, RowObject rowObject)
+        {
+            if (formObject == null)
+            {
+                throw new ArgumentNullException(nameof(formObject));
+            }
+
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            if (!formObject.MultipleIteration && formObject.CurrentRow != null)
+            {
+                throw new ArgumentException("Cannot add another row to a non-multiple-iteration form.", nameof(formObject));
+            }
+
+            if (!string.IsNullOrEmpty(rowObject.RowId) && formObject.IsRowPresent(rowObject.RowId))
+            {
+                throw new ArgumentException("A row with the provided RowId already exists.", nameof(rowObject));
+            }
+
+            if (formObject.CurrentRow == null)
+            {
+                if (string.IsNullOrEmpty(rowObject.RowId))
+                {
+                    rowObject.RowId = formObject.GetNextAvailableRowId();
+                }
+
+                formObject.CurrentRow = rowObject;
+                return formObject;
+            }
+
+            if (string.IsNullOrEmpty(rowObject.RowId))
+            {
+                rowObject.RowId = formObject.GetNextAvailableRowId();
+            }
+
+            if (formObject.OtherRows == null)
+            {
+                formObject.OtherRows = new List<RowObject>();
+            }
+
+            formObject.OtherRows.Add(rowObject);
+            return formObject;
+        }
+
+        /// <summary>
+        /// Adds a new row to a <see cref="FormObject"/> with row action set to <see cref="RowObject.RowActions.Add"/>.
+        /// </summary>
+        /// <param name="formObject">The form to modify.</param>
+        /// <returns>The modified form.</returns>
+        public static FormObject AddRowObject(this FormObject formObject)
+        {
+            return formObject.AddRowObject(new RowObject
+            {
+                RowAction = RowObject.RowActions.Add
+            });
+        }
+
+        /// <summary>
+        /// Adds a new row to a <see cref="FormObject"/> with a specific row ID and parent row ID.
+        /// </summary>
+        /// <param name="formObject">The form to modify.</param>
+        /// <param name="rowId">The row ID to assign.</param>
+        /// <param name="parentRowId">The parent row ID to assign.</param>
+        /// <returns>The modified form.</returns>
+        public static FormObject AddRowObject(this FormObject formObject, string rowId, string parentRowId)
+        {
+            return formObject.AddRowObject(rowId, parentRowId, RowObject.RowActions.Add);
+        }
+
+        /// <summary>
+        /// Adds a new row to a <see cref="FormObject"/> with specific row and parent identifiers and row action.
+        /// </summary>
+        /// <param name="formObject">The form to modify.</param>
+        /// <param name="rowId">The row ID to assign.</param>
+        /// <param name="parentRowId">The parent row ID to assign.</param>
+        /// <param name="rowAction">The row action to assign.</param>
+        /// <returns>The modified form.</returns>
+        public static FormObject AddRowObject(this FormObject formObject, string rowId, string parentRowId, string rowAction)
+        {
+            return formObject.AddRowObject(new RowObject
+            {
+                RowId = rowId,
+                ParentRowId = parentRowId,
+                RowAction = rowAction
+            });
+        }
+
+        /// <summary>
+        /// Adds a new row to a <see cref="FormObject"/> with row action set to <see cref="RowObject.RowActions.Add"/> and the specified parent row ID.
+        /// </summary>
+        /// <param name="formObject">The form to modify.</param>
+        /// <param name="parentRowId">The parent row ID to assign.</param>
+        /// <returns>The modified form.</returns>
+        public static FormObject AddRowObjectWithParentRowId(this FormObject formObject, string parentRowId)
+        {
+            return formObject.AddRowObject(new RowObject
+            {
+                ParentRowId = parentRowId,
+                RowAction = RowObject.RowActions.Add
+            });
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in a <see cref="FormObject"/>.
+        /// </summary>
+        /// <param name="formObject">The form to modify.</param>
+        /// <param name="rowObject">The row to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the row ID is missing or no matching row is found.</exception>
+        /// <returns>The modified form.</returns>
+        public static FormObject DeleteRowObject(this FormObject formObject, RowObject rowObject)
+        {
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            return formObject.DeleteRowObject(rowObject.RowId);
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in a <see cref="FormObject"/> by row ID.
+        /// </summary>
+        /// <param name="formObject">The form to modify.</param>
+        /// <param name="rowId">The row ID to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="formObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="rowId"/> is null/empty or no matching row is found.</exception>
+        /// <returns>The modified form.</returns>
+        public static FormObject DeleteRowObject(this FormObject formObject, string rowId)
+        {
+            if (formObject == null)
+            {
+                throw new ArgumentNullException(nameof(formObject));
+            }
+
+            if (string.IsNullOrEmpty(rowId))
+            {
+                throw new ArgumentException("RowId cannot be null or empty.", nameof(rowId));
+            }
+
+            if (formObject.CurrentRow?.RowId == rowId)
+            {
+                formObject.CurrentRow.RowAction = RowObject.RowActions.Delete;
+                return formObject;
+            }
+
+            if (formObject.MultipleIteration && formObject.OtherRows != null)
+            {
+                var rowIndex = formObject.OtherRows.FindIndex(r => r != null && r.RowId == rowId);
+                if (rowIndex >= 0)
+                {
+                    formObject.OtherRows[rowIndex].RowAction = RowObject.RowActions.Delete;
+                    return formObject;
+                }
+            }
+
+            throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -104,11 +104,6 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
                 throw new ArgumentOutOfRangeException(nameof(formObject), "Cannot add another row to a non-multiple-iteration form.");
             }
 
-            if (currentRow != null && otherRows.Count + 1 >= MaximumNumberOfMultipleIterationRows)
-            {
-                throw new ArgumentOutOfRangeException(nameof(formObject), "Cannot add another row because the maximum row count was reached.");
-            }
-
             for (int i = 1; i <= MaximumNumberOfMultipleIterationRows; i++)
             {
                 var candidateRowId = string.Concat(formObject.FormId, "||", i.ToString());

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/FormObjectHelpers.cs
@@ -287,7 +287,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
                 return formObject;
             }
 
-            if (formObject.MultipleIteration && formObject.OtherRows != null)
+            if (formObject.OtherRows != null)
             {
                 var rowIndex = formObject.OtherRows.FindIndex(r => r != null && r.RowId == rowId);
                 if (rowIndex >= 0)

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -95,6 +95,129 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         }
 
         /// <summary>
+        /// Gets the next available row ID for a form in an <see cref="OptionObject2015"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to query.</param>
+        /// <param name="formId">The target form ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty or the form is not found.</exception>
+        /// <returns>The next available row ID.</returns>
+        public static string GetNextAvailableRowId(this OptionObject2015 optionObject, string formId)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(formId))
+            {
+                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+            }
+
+            var formObject = optionObject.Forms?.FirstOrDefault(f => f != null && f.FormId == formId);
+            if (formObject == null)
+            {
+                throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
+            }
+
+            return formObject.GetNextAvailableRowId();
+        }
+
+        /// <summary>
+        /// Adds a row to a form in an <see cref="OptionObject2015"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="formId">The target form ID.</param>
+        /// <param name="rowObject">The row to add.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject2015 AddRowObject(this OptionObject2015 optionObject, string formId, RowObject rowObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(formId))
+            {
+                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+            }
+
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            var forms = optionObject.Forms;
+            if (forms == null)
+            {
+                return optionObject;
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.FormId == formId);
+            if (formIndex >= 0)
+            {
+                forms[formIndex].AddRowObject(rowObject);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in an <see cref="OptionObject2015"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="rowObject">The row to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject2015 DeleteRowObject(this OptionObject2015 optionObject, RowObject rowObject)
+        {
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            return optionObject.DeleteRowObject(rowObject.RowId);
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in an <see cref="OptionObject2015"/> by row ID.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="rowId">The row ID to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="rowId"/> is null/empty or no matching row is found.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject2015 DeleteRowObject(this OptionObject2015 optionObject, string rowId)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(rowId))
+            {
+                throw new ArgumentException("RowId cannot be null or empty.", nameof(rowId));
+            }
+
+            var forms = optionObject.Forms;
+            if (forms == null)
+            {
+                throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.IsRowPresent(rowId));
+            if (formIndex >= 0)
+            {
+                forms[formIndex].DeleteRowObject(rowId);
+                return optionObject;
+            }
+
+            throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+        }
+
+        /// <summary>
         /// Disables a <see cref="FieldObject"/> in an <see cref="OptionObject2015"/> by field number.
         /// </summary>
         /// <param name="optionObject">The OptionObject2015 to modify.</param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -130,7 +130,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// <param name="formId">The target form ID.</param>
         /// <param name="rowObject">The row to add.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="rowObject"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty or the form is not found.</exception>
         /// <returns>The modified option object.</returns>
         public static OptionObject2015 AddRowObject(this OptionObject2015 optionObject, string formId, RowObject rowObject)
         {
@@ -159,9 +159,10 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (formIndex >= 0)
             {
                 forms[formIndex].AddRowObject(rowObject);
+                return optionObject;
             }
 
-            return optionObject;
+            throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2015Helpers.cs
@@ -111,14 +111,10 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(formId))
             {
-                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+                throw new ArgumentException(StructuralMutationMessages.FormIdCannotBeNullOrEmpty, nameof(formId));
             }
 
-            var formObject = optionObject.Forms?.FirstOrDefault(f => f != null && f.FormId == formId);
-            if (formObject == null)
-            {
-                throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
-            }
+            var formObject = StructuralMutationCore.GetFormObjectOrThrow(optionObject.Forms, formId);
 
             return formObject.GetNextAvailableRowId();
         }
@@ -141,7 +137,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(formId))
             {
-                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+                throw new ArgumentException(StructuralMutationMessages.FormIdCannotBeNullOrEmpty, nameof(formId));
             }
 
             if (rowObject == null)
@@ -149,20 +145,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
                 throw new ArgumentNullException(nameof(rowObject));
             }
 
-            var forms = optionObject.Forms;
-            if (forms == null)
-            {
-                return optionObject;
-            }
-
-            var formIndex = forms.FindIndex(f => f != null && f.FormId == formId);
-            if (formIndex >= 0)
-            {
-                forms[formIndex].AddRowObject(rowObject);
-                return optionObject;
-            }
-
-            throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
+            StructuralMutationCore.AddRowObject(optionObject.Forms, formId, rowObject);
+            return optionObject;
         }
 
         /// <summary>
@@ -199,23 +183,11 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(rowId))
             {
-                throw new ArgumentException("RowId cannot be null or empty.", nameof(rowId));
+                throw new ArgumentException(StructuralMutationMessages.RowIdCannotBeNullOrEmpty, nameof(rowId));
             }
 
-            var forms = optionObject.Forms;
-            if (forms == null)
-            {
-                throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
-            }
-
-            var formIndex = forms.FindIndex(f => f != null && f.IsRowPresent(rowId));
-            if (formIndex >= 0)
-            {
-                forms[formIndex].DeleteRowObject(rowId);
-                return optionObject;
-            }
-
-            throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+            StructuralMutationCore.DeleteRowObject(optionObject.Forms, rowId);
+            return optionObject;
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -110,7 +110,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// <param name="formId">The target form ID.</param>
         /// <param name="rowObject">The row to add.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="rowObject"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty or the form is not found.</exception>
         /// <returns>The modified option object.</returns>
         public static OptionObject2 AddRowObject(this OptionObject2 optionObject, string formId, RowObject rowObject)
         {
@@ -139,9 +139,10 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (formIndex >= 0)
             {
                 forms[formIndex].AddRowObject(rowObject);
+                return optionObject;
             }
 
-            return optionObject;
+            throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -91,14 +91,10 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(formId))
             {
-                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+                throw new ArgumentException(StructuralMutationMessages.FormIdCannotBeNullOrEmpty, nameof(formId));
             }
 
-            var formObject = optionObject.Forms?.FirstOrDefault(f => f != null && f.FormId == formId);
-            if (formObject == null)
-            {
-                throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
-            }
+            var formObject = StructuralMutationCore.GetFormObjectOrThrow(optionObject.Forms, formId);
 
             return formObject.GetNextAvailableRowId();
         }
@@ -121,7 +117,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(formId))
             {
-                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+                throw new ArgumentException(StructuralMutationMessages.FormIdCannotBeNullOrEmpty, nameof(formId));
             }
 
             if (rowObject == null)
@@ -129,20 +125,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
                 throw new ArgumentNullException(nameof(rowObject));
             }
 
-            var forms = optionObject.Forms;
-            if (forms == null)
-            {
-                return optionObject;
-            }
-
-            var formIndex = forms.FindIndex(f => f != null && f.FormId == formId);
-            if (formIndex >= 0)
-            {
-                forms[formIndex].AddRowObject(rowObject);
-                return optionObject;
-            }
-
-            throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
+            StructuralMutationCore.AddRowObject(optionObject.Forms, formId, rowObject);
+            return optionObject;
         }
 
         /// <summary>
@@ -179,23 +163,11 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(rowId))
             {
-                throw new ArgumentException("RowId cannot be null or empty.", nameof(rowId));
+                throw new ArgumentException(StructuralMutationMessages.RowIdCannotBeNullOrEmpty, nameof(rowId));
             }
 
-            var forms = optionObject.Forms;
-            if (forms == null)
-            {
-                throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
-            }
-
-            var formIndex = forms.FindIndex(f => f != null && f.IsRowPresent(rowId));
-            if (formIndex >= 0)
-            {
-                forms[formIndex].DeleteRowObject(rowId);
-                return optionObject;
-            }
-
-            throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+            StructuralMutationCore.DeleteRowObject(optionObject.Forms, rowId);
+            return optionObject;
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObject2Helpers.cs
@@ -75,6 +75,129 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         }
 
         /// <summary>
+        /// Gets the next available row ID for a form in an <see cref="OptionObject2"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to query.</param>
+        /// <param name="formId">The target form ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty or the form is not found.</exception>
+        /// <returns>The next available row ID.</returns>
+        public static string GetNextAvailableRowId(this OptionObject2 optionObject, string formId)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(formId))
+            {
+                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+            }
+
+            var formObject = optionObject.Forms?.FirstOrDefault(f => f != null && f.FormId == formId);
+            if (formObject == null)
+            {
+                throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
+            }
+
+            return formObject.GetNextAvailableRowId();
+        }
+
+        /// <summary>
+        /// Adds a row to a form in an <see cref="OptionObject2"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="formId">The target form ID.</param>
+        /// <param name="rowObject">The row to add.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject2 AddRowObject(this OptionObject2 optionObject, string formId, RowObject rowObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(formId))
+            {
+                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+            }
+
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            var forms = optionObject.Forms;
+            if (forms == null)
+            {
+                return optionObject;
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.FormId == formId);
+            if (formIndex >= 0)
+            {
+                forms[formIndex].AddRowObject(rowObject);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in an <see cref="OptionObject2"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="rowObject">The row to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject2 DeleteRowObject(this OptionObject2 optionObject, RowObject rowObject)
+        {
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            return optionObject.DeleteRowObject(rowObject.RowId);
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in an <see cref="OptionObject2"/> by row ID.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="rowId">The row ID to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="rowId"/> is null/empty or no matching row is found.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject2 DeleteRowObject(this OptionObject2 optionObject, string rowId)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(rowId))
+            {
+                throw new ArgumentException("RowId cannot be null or empty.", nameof(rowId));
+            }
+
+            var forms = optionObject.Forms;
+            if (forms == null)
+            {
+                throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.IsRowPresent(rowId));
+            if (formIndex >= 0)
+            {
+                forms[formIndex].DeleteRowObject(rowId);
+                return optionObject;
+            }
+
+            throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+        }
+
+        /// <summary>
         /// Disables a <see cref="FieldObject"/> in an <see cref="OptionObject2"/> by field number.
         /// </summary>
         /// <param name="optionObject">The OptionObject2 to modify.</param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -123,14 +123,10 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(formId))
             {
-                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+                throw new ArgumentException(StructuralMutationMessages.FormIdCannotBeNullOrEmpty, nameof(formId));
             }
 
-            var formObject = optionObject.Forms?.FirstOrDefault(f => f != null && f.FormId == formId);
-            if (formObject == null)
-            {
-                throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
-            }
+            var formObject = StructuralMutationCore.GetFormObjectOrThrow(optionObject.Forms, formId);
 
             return formObject.GetNextAvailableRowId();
         }
@@ -153,7 +149,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(formId))
             {
-                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+                throw new ArgumentException(StructuralMutationMessages.FormIdCannotBeNullOrEmpty, nameof(formId));
             }
 
             if (rowObject == null)
@@ -161,20 +157,8 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
                 throw new ArgumentNullException(nameof(rowObject));
             }
 
-            var forms = optionObject.Forms;
-            if (forms == null)
-            {
-                return optionObject;
-            }
-
-            var formIndex = forms.FindIndex(f => f != null && f.FormId == formId);
-            if (formIndex >= 0)
-            {
-                forms[formIndex].AddRowObject(rowObject);
-                return optionObject;
-            }
-
-            throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
+            StructuralMutationCore.AddRowObject(optionObject.Forms, formId, rowObject);
+            return optionObject;
         }
 
         /// <summary>
@@ -211,23 +195,11 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
 
             if (string.IsNullOrEmpty(rowId))
             {
-                throw new ArgumentException("RowId cannot be null or empty.", nameof(rowId));
+                throw new ArgumentException(StructuralMutationMessages.RowIdCannotBeNullOrEmpty, nameof(rowId));
             }
 
-            var forms = optionObject.Forms;
-            if (forms == null)
-            {
-                throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
-            }
-
-            var formIndex = forms.FindIndex(f => f != null && f.IsRowPresent(rowId));
-            if (formIndex >= 0)
-            {
-                forms[formIndex].DeleteRowObject(rowId);
-                return optionObject;
-            }
-
-            throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+            StructuralMutationCore.DeleteRowObject(optionObject.Forms, rowId);
+            return optionObject;
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -107,6 +107,129 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         }
 
         /// <summary>
+        /// Gets the next available row ID for a form in an <see cref="OptionObject"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to query.</param>
+        /// <param name="formId">The target form ID.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty or the form is not found.</exception>
+        /// <returns>The next available row ID.</returns>
+        public static string GetNextAvailableRowId(this OptionObject optionObject, string formId)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(formId))
+            {
+                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+            }
+
+            var formObject = optionObject.Forms?.FirstOrDefault(f => f != null && f.FormId == formId);
+            if (formObject == null)
+            {
+                throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
+            }
+
+            return formObject.GetNextAvailableRowId();
+        }
+
+        /// <summary>
+        /// Adds a row to a form in an <see cref="OptionObject"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="formId">The target form ID.</param>
+        /// <param name="rowObject">The row to add.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="rowObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject AddRowObject(this OptionObject optionObject, string formId, RowObject rowObject)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(formId))
+            {
+                throw new ArgumentException("FormId cannot be null or empty.", nameof(formId));
+            }
+
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            var forms = optionObject.Forms;
+            if (forms == null)
+            {
+                return optionObject;
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.FormId == formId);
+            if (formIndex >= 0)
+            {
+                forms[formIndex].AddRowObject(rowObject);
+            }
+
+            return optionObject;
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in an <see cref="OptionObject"/>.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="rowObject">The row to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="rowObject"/> is null.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject DeleteRowObject(this OptionObject optionObject, RowObject rowObject)
+        {
+            if (rowObject == null)
+            {
+                throw new ArgumentNullException(nameof(rowObject));
+            }
+
+            return optionObject.DeleteRowObject(rowObject.RowId);
+        }
+
+        /// <summary>
+        /// Marks a row for deletion in an <see cref="OptionObject"/> by row ID.
+        /// </summary>
+        /// <param name="optionObject">The option object to modify.</param>
+        /// <param name="rowId">The row ID to mark for deletion.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="rowId"/> is null/empty or no matching row is found.</exception>
+        /// <returns>The modified option object.</returns>
+        public static OptionObject DeleteRowObject(this OptionObject optionObject, string rowId)
+        {
+            if (optionObject == null)
+            {
+                throw new ArgumentNullException(nameof(optionObject));
+            }
+
+            if (string.IsNullOrEmpty(rowId))
+            {
+                throw new ArgumentException("RowId cannot be null or empty.", nameof(rowId));
+            }
+
+            var forms = optionObject.Forms;
+            if (forms == null)
+            {
+                throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.IsRowPresent(rowId));
+            if (formIndex >= 0)
+            {
+                forms[formIndex].DeleteRowObject(rowId);
+                return optionObject;
+            }
+
+            throw new ArgumentException("No matching row was found for the provided rowId.", nameof(rowId));
+        }
+
+        /// <summary>
         /// Gets the field value of a <see cref="FieldObject"/> in an <see cref="OptionObject"/> by field number (searches all forms).
         /// </summary>
         /// <param name="optionObject">The OptionObject to query.</param>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/OptionObjectHelpers.cs
@@ -142,7 +142,7 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
         /// <param name="formId">The target form ID.</param>
         /// <param name="rowObject">The row to add.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="optionObject"/> or <paramref name="rowObject"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="formId"/> is null/empty or the form is not found.</exception>
         /// <returns>The modified option object.</returns>
         public static OptionObject AddRowObject(this OptionObject optionObject, string formId, RowObject rowObject)
         {
@@ -171,9 +171,10 @@ namespace RarelySimple.AvatarScriptLink.Objects.Helpers
             if (formIndex >= 0)
             {
                 forms[formIndex].AddRowObject(rowObject);
+                return optionObject;
             }
 
-            return optionObject;
+            throw new ArgumentException("No matching form was found for the provided formId.", nameof(formId));
         }
 
         /// <summary>

--- a/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/StructuralMutationCore.cs
+++ b/dotnet/RarelySimple.AvatarScriptLink.Objects.Helpers/StructuralMutationCore.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace RarelySimple.AvatarScriptLink.Objects.Helpers
+{
+    internal static class StructuralMutationMessages
+    {
+        internal const string FormIdCannotBeNullOrEmpty = "FormId cannot be null or empty.";
+        internal const string RowIdCannotBeNullOrEmpty = "RowId cannot be null or empty.";
+        internal const string NoMatchingFormForFormId = "No matching form was found for the provided formId.";
+        internal const string NoMatchingRowForRowId = "No matching row was found for the provided rowId.";
+    }
+
+    internal static class StructuralMutationCore
+    {
+        internal static FormObject GetFormObjectOrThrow(List<FormObject> forms, string formId)
+        {
+            var formObject = forms?.Find(f => f != null && f.FormId == formId);
+            if (formObject == null)
+            {
+                throw new ArgumentException(StructuralMutationMessages.NoMatchingFormForFormId, nameof(formId));
+            }
+
+            return formObject;
+        }
+
+        internal static void AddRowObject(List<FormObject> forms, string formId, RowObject rowObject)
+        {
+            if (forms == null)
+            {
+                throw new ArgumentException(StructuralMutationMessages.NoMatchingFormForFormId, nameof(formId));
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.FormId == formId);
+            if (formIndex >= 0)
+            {
+                forms[formIndex].AddRowObject(rowObject);
+                return;
+            }
+
+            throw new ArgumentException(StructuralMutationMessages.NoMatchingFormForFormId, nameof(formId));
+        }
+
+        internal static void DeleteRowObject(List<FormObject> forms, string rowId)
+        {
+            if (forms == null)
+            {
+                throw new ArgumentException(StructuralMutationMessages.NoMatchingRowForRowId, nameof(rowId));
+            }
+
+            var formIndex = forms.FindIndex(f => f != null && f.IsRowPresent(rowId));
+            if (formIndex >= 0)
+            {
+                forms[formIndex].DeleteRowObject(rowId);
+                return;
+            }
+
+            throw new ArgumentException(StructuralMutationMessages.NoMatchingRowForRowId, nameof(rowId));
+        }
+    }
+}


### PR DESCRIPTION
- Implement GetNextAvailableRowId method for FormObject to retrieve the next available row ID.
- Enhance AddRowObject method in FormObject to support adding rows with generated IDs and handle various scenarios.
- Introduce DeleteRowObject method in FormObject for marking rows for deletion.
- Extend OptionObject and OptionObject2 helpers with methods to manage rows, including adding and deleting rows by form ID.
- Add tests for new functionalities to ensure proper behavior and error handling.